### PR TITLE
feat: guardrails do loop, integrações Groq/DeepSeek, .env e bateria de testes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,53 @@
+# =============================================================================
+# IAC — Variáveis de ambiente (.env.example)
+# =============================================================================
+# Copie este arquivo para .iac/.env no projeto inspecionado e preencha os valores.
+# Hierarquia: .env → variáveis de ambiente → CLI args (CLI tem prioridade)
+#
+# Uso:
+#   cp .env.example /caminho/projeto/.iac/.env
+#   # editar e preencher valores
+#   iac analyze --base-dir /caminho/projeto --issue-url URL
+
+# -----------------------------------------------------------------------------
+# GitLab
+# -----------------------------------------------------------------------------
+# GITLAB_TOKEN=glpat-...
+
+# -----------------------------------------------------------------------------
+# LLM Backend (ollama | groq | deepseek | gemini)
+# -----------------------------------------------------------------------------
+# IAC_LLM_BACKEND=groq
+# IAC_LLM_MODEL=llama-3.3-70b-versatile
+# IAC_LLM_URL=
+# IAC_LLM_KEY=
+
+# -----------------------------------------------------------------------------
+# Rate limit (genérico — aplica para qualquer backend remoto)
+# -----------------------------------------------------------------------------
+# IAC_LLM_RATE_DELAY=30
+# IAC_LLM_MAX_RETRIES=3
+
+# -----------------------------------------------------------------------------
+# Groq (https://console.groq.com/keys)
+# Gratuito com rate limit. Modelos: llama-3.3-70b-versatile, llama-3.1-8b-instant,
+# qwen/qwen3-32b, meta-llama/llama-4-scout-17b-16e-instruct
+# -----------------------------------------------------------------------------
+# GROQ_API_KEY=gsk_...
+
+# -----------------------------------------------------------------------------
+# DeepSeek (https://platform.deepseek.com/api_keys)
+# $5 grátis. Modelos: deepseek-coder, deepseek-chat, deepseek-reasoner
+# -----------------------------------------------------------------------------
+# DEEPSEEK_API_KEY=sk-...
+
+# -----------------------------------------------------------------------------
+# Gemini (https://aistudio.google.com/apikey)
+# 50 req/dia grátis. Modelos: gemini-2.5-pro, gemini-2.0-flash
+# -----------------------------------------------------------------------------
+# GEMINI_API_KEY=AIza...
+
+# -----------------------------------------------------------------------------
+# Análise
+# -----------------------------------------------------------------------------
+# IAC_ANALYZE_MODE=multi

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -1,0 +1,59 @@
+## Docker Compose para Ollama + Open WebUI
+##
+## Uso:
+##   # Subir Ollama + Open WebUI:
+##   docker compose -f docker-compose.ollama.yml up -d
+##
+##   # Baixar modelo (ex: qwen2.5-coder:7b, qwen2.5-coder:14b):
+##   docker exec ollama ollama pull qwen2.5-coder:7b
+##
+##   # Testar via API:
+##   curl http://localhost:11434/v1/chat/completions \
+##     -H "Content-Type: application/json" \
+##     -d '{"model":"qwen2.5-coder:7b","messages":[{"role":"user","content":"Olá"}]}'
+##
+##   # Acessar Open WebUI:
+##   http://localhost:3000
+##
+##   # Usar no IAC:
+##   iac analyze --llm ollama --llm-model qwen2.5-coder:7b ...
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    ports:
+      - "${OLLAMA_PORT:-11434}:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+      - OLLAMA_NUM_PARALLEL=1
+      - OLLAMA_MAX_LOADED_MODELS=1
+    # Sem GPU: roda em CPU. Para GPU NVIDIA, descomentar:
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    restart: unless-stopped
+    ports:
+      - "${OPENWEBUI_PORT:-3000}:8080"
+    volumes:
+      - openwebui_data:/app/backend/data
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+      - WEBUI_AUTH=false
+    depends_on:
+      - ollama
+
+volumes:
+  ollama_data:
+  openwebui_data:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,21 +1,21 @@
 # Arquitetura — Incident Analyst Agent (IAC)
 
-Agente de análise técnica de incidentes de software. Investiga código, reconstrói fluxos, classifica causa e propõe resolução com resposta operacional estruturada.
+Agente de análise técnica de incidentes de software. Investiga código, reconstrói fluxos, classifica causa e propõe resolução com relatório técnico estruturado.
 
 ## Princípios — Arquitetura AI-Native
 
 Este projeto segue os 6 princípios da [Arquitetura AI-Native](https://lemon.dev.br/pt/blog/arquitetura-ai-native-sistemas-ia), adaptados para uma CLI de análise de código + LLM.
 
-| Princípio | Aplicação no IAC |
-|-----------|-----------------|
-| **1. Explícito sobre Implícito** | `AppSettings` com Pydantic Settings, `config.yaml` tipado, perfis de modelo explícitos |
-| **2. Módulos < 200 linhas** | `orchestrator.py` decomposto em `investigate.py`, `deep.py`, `structural.py`, `format.py` |
-| **3. Contract-First** | Pydantic models: `Classification`, `InvestigationContext`, `StructuralAnalysis`, `DeepModel`, `AnalysisResult` |
-| **4. Testes Determinísticos** | 106 testes com fixtures em memória, respostas LLM pré-gravadas (sem Ollama) |
-| **5. Sistemas Autodescritivos** | Este documento, docstrings Google style, logging por camada `[Camada N]` |
-| **6. Verificação Automatizada** | `ruff` (lint + docstrings), `pytest`, GitHub Actions CI, `.pre-commit-config.yaml` |
+| Princípio | Aplicação no IAC | Score |
+|-----------|-----------------|-------|
+| **1. Explícito sobre Implícito** | `AppSettings` (Pydantic Settings), `.env` com todas as variáveis, `KNOWN_TIPOS` + `_LABEL_ALIASES` codificam taxonomia, `MODEL_PROFILES` explícitos | ✅ |
+| **2. Módulos < 400 linhas** | `orchestrator.py` decomposto em 6 módulos, prompts em pacote próprio, pylint `max-module-lines=400` | ✅ |
+| **3. Contract-First** | Pydantic models: `Classification`, `InvestigationContext`, `StructuralAnalysis`, `DeepModel`, `AnalysisResult` | ⚠️ parcial |
+| **4. Testes Determinísticos** | 153 testes com fixtures em memória, respostas LLM mockadas, testes de integração (413/429/fallback) | ✅ |
+| **5. Sistemas Autodescritivos** | `.iac/structure.json`, `.iac/graph.json`, `docs/ARCHITECTURE.md`, docstrings Google style, logging por camada | ✅ |
+| **6. Verificação Automatizada** | `ruff` (lint + docstrings), `pylint` (tamanho), `pytest`, GitHub Actions CI, `.pre-commit-config.yaml` | ✅ |
 
-Referências: [artigo original](https://lemon.dev.br/pt/blog/arquitetura-ai-native-sistemas-ia), [adaptação siscan-rpa](https://github.com/Prisma-Consultoria/siscan-rpa/pull/577).
+Scorecard detalhado: [issue #36](https://github.com/jailtoncarlos/incident-analyst-agent/issues/36#issuecomment-4212053047).
 
 ## Visão geral
 
@@ -30,9 +30,9 @@ graph TD
     C2 --> D
     C3 --> D
     C4 --> D
-    D --> E[LLM - Ollama/Gemini]
-    E --> F[Classificação + Análise]
-    F --> G[Resposta ao Usuário]
+    D --> E[LLM — Ollama/Groq/DeepSeek/Gemini]
+    E --> F[Classificação + Subclassificação]
+    F --> G[Relatório Técnico]
 ```
 
 ## Pipeline de análise
@@ -40,12 +40,15 @@ graph TD
 ```mermaid
 sequenceDiagram
     participant CLI as iac analyze
+    participant ENV as .env
     participant CL as Classifier
     participant OR as Orchestrator
     participant ST as Structural
     participant DP as Deep
     participant PR as Prompts
     participant LLM as LLM
+
+    CLI->>ENV: carregar variáveis (.iac/.env)
 
     CLI->>CL: title + description
     CL-->>CLI: Classification (origem, app, interessado, labels)
@@ -59,20 +62,21 @@ sequenceDiagram
     CLI->>DP: context + graph + FKs
     DP-->>CLI: DeepModel[] (fields, constants, methods)
 
-    CLI->>PR: AnalysisResult
-    PR-->>CLI: prompt (investigation)
+    CLI->>PR: AnalysisResult + mode
+    alt single
+        PR-->>LLM: 1 prompt (tudo junto)
+    else multi
+        PR-->>LLM: prompt 1 (investigação)
+        LLM-->>PR: pedidos
+        PR-->>LLM: prompt 2 (análise com evidência)
+    else loop
+        PR-->>LLM: prompt iterativo (INVESTIGAR/CLASSIFICAR)
+        LLM-->>PR: ação por iteração (max 4)
+    end
 
-    CLI->>LLM: prompt 1 (investigação)
-    LLM-->>CLI: pedidos de investigação
-
-    CLI->>PR: evidence + view code
-    PR-->>CLI: prompt (análise)
-
-    CLI->>LLM: prompt 2 (análise)
-    LLM-->>CLI: classificação + análise
-
-    CLI->>LLM: prompt 3 (resposta)
-    LLM-->>CLI: rascunho "Prezado(a)..."
+    LLM-->>CLI: classificação + subclassificação + análise
+    CLI->>LLM: prompt 3 (relatório técnico)
+    LLM-->>CLI: relatório para o desenvolvedor
 ```
 
 ## Estrutura do projeto
@@ -80,16 +84,16 @@ sequenceDiagram
 ```
 src/iac/
 ├── __init__.py
-├── models.py                  # Contratos de dados — Pydantic models (P3)
+├── models.py                  # Contratos de dados — Pydantic models
 ├── cli.py                     # Entry point CLI (iac init/analyze/diagram/config)
 │
 ├── config/
-│   ├── app_settings.py        # AppSettings — Pydantic Settings tipado (P1)
-│   └── settings.py            # Load/save .iac/ files + config.yaml
+│   ├── app_settings.py        # AppSettings — Pydantic Settings + env vars
+│   └── settings.py            # Load/save .iac/ files + config.yaml + .env
 │
 ├── inspector/                 # Camada 1 — Inspeção estrutural
 │   ├── detector.py            # Detecta framework (Django/Flask/FastAPI)
-│   ├── django.py              # Façade: build_django_structure() (P2)
+│   ├── django.py              # Façade: build_django_structure()
 │   ├── django_discovery.py    # Descoberta de apps e INSTALLED_APPS
 │   ├── django_parser.py       # Parsing AST de módulos Python
 │   ├── django_urls.py         # Parsing de urls.py e admin.py
@@ -98,39 +102,66 @@ src/iac/
 │   └── graph.py               # Gera graph.json (arestas tipadas)
 │
 ├── agent/                     # Camadas 2-4 — Recuperação e orquestração
-│   ├── orchestrator.py        # Façade: analyze_issue() + perfis de modelo (P2)
-│   ├── investigate.py         # Camada 2: navegação de código via .iac/ (P2)
-│   ├── deep.py                # Camada 4: FKs em profundidade (P2)
-│   ├── structural.py          # Camada 3: componentes + fluxo (P2)
-│   ├── format.py              # Formatação de contexto para prompts (P2)
-│   ├── tools.py               # Façade: 7 ferramentas de navegação (P2)
+│   ├── orchestrator.py        # Façade: analyze_issue() + MODEL_PROFILES
+│   ├── investigate.py         # Camada 2: navegação de código via .iac/
+│   ├── deep.py                # Camada 4: FKs em profundidade
+│   ├── structural.py          # Camada 3: componentes + fluxo
+│   ├── format.py              # Formatação de contexto para prompts
+│   ├── tools.py               # Façade: 7 ferramentas de navegação
 │   ├── tools_navigation.py    # resolver_rota, localizar_arquivo, ler_funcao
 │   ├── tools_inspection.py    # extrair_chamadas, seguir_referencia, listar_imports
-│   ├── runner.py              # Runner LLM: single/multi-prompt (P2)
-│   └── prompts/               # Pacote de prompts (P2)
-│       ├── analysis.py        # Prompt single-prompt (análise completa)
+│   ├── runner.py              # Runner LLM: single/multi/loop/auto + rate limit
+│   ├── loop.py                # Loop interativo com guardrails
+│   └── prompts/               # Pacote de prompts
+│       ├── analysis.py        # Prompt single-prompt (com ajuste progressivo)
 │       ├── multi.py           # Prompts multi-prompt (investigação + evidência)
-│       ├── response.py        # Prompt de resposta ao usuário
-│       └── utils.py           # Extração de tipo + compactação
+│       ├── response.py        # Prompt de relatório técnico para o dev
+│       └── utils.py           # Extração de tipo, taxonomia, compactação
 │
 ├── analyzer/
 │   ├── classifier.py          # Classificação sem LLM (origem, app, interessado)
-│   └── simulator.py           # Simulação em ambiente controlado (stub)
-│
-├── responder/
-│   └── generator.py           # Gerador de resposta ao usuário (stub)
+│   └── simulator.py           # Simulação em ambiente controlado (stub — #44)
 │
 ├── integrations/
 │   ├── gitlab.py              # Client GitLab (buscar issue, postar comentário)
-│   ├── ollama.py              # Backend LLM Ollama (local/self-hosted)
+│   ├── ollama.py              # Backend LLM Ollama (local, timeout 1200s)
+│   ├── groq.py                # Backend LLM Groq (gratuito, retry 429/413)
+│   ├── deepseek.py            # Backend LLM DeepSeek ($5 grátis, retry 429/413)
 │   └── gemini.py              # Backend LLM Google Gemini
 │
 └── diagram/
     ├── generator.py           # Dados para visualização D3.js
     └── templates/
         ├── overview.html      # Apps como nós (force-directed graph)
-        └── app_detail.html    # Detalhe por app (views, models, forms, templates)
+        └── app_detail.html    # Detalhe por app
 ```
+
+## Configuração via .env
+
+Todas as variáveis em `.iac/.env`, carregado automaticamente. CLI args sempre têm prioridade.
+
+```bash
+# GitLab
+GITLAB_TOKEN=glpat-...
+
+# LLM Backend (ollama | groq | deepseek | gemini)
+IAC_LLM_BACKEND=groq
+IAC_LLM_MODEL=llama-3.3-70b-versatile
+
+# Rate limit (genérico — aplica para qualquer backend remoto)
+IAC_LLM_RATE_DELAY=30
+IAC_LLM_MAX_RETRIES=3
+
+# API keys por backend
+GROQ_API_KEY=gsk_...
+# DEEPSEEK_API_KEY=sk-...
+# GEMINI_API_KEY=AIza...
+
+# Modo padrão
+IAC_ANALYZE_MODE=multi
+```
+
+Template completo: `.env.example` na raiz do projeto.
 
 ## Artefatos gerados (.iac/)
 
@@ -139,26 +170,61 @@ src/iac/
 ├── project.json       # Framework, versão, settings
 ├── structure.json     # Mapa de apps/views/models/forms/admin/urls
 ├── graph.json         # Grafo de dependências (arestas tipadas)
-├── config.yaml        # Configurações persistentes (LLM, GitLab, modo)
+├── config.yaml        # Configurações persistentes (opcional, .env preferido)
+├── .env               # Variáveis de ambiente (não commitado)
 ├── logs/
-│   └── iac.log        # Log DEBUG completo (sempre gravado)
+│   ├── iac_YYYYMMDD_HHMMSS.log  # Log DEBUG por execução
+│   └── groq/                     # Logs de bateria Groq
 └── diagrams/
     ├── overview.html   # Visão geral dos apps
     └── *.html          # Detalhe por app
 ```
 
-## Contratos de dados (Pydantic models)
+## Backends LLM
 
-```
-Classification          → Camada 1 (classifier)
-InvestigationContext    → Camada 2 (orchestrator/investigate)
-StructuralAnalysis     → Camada 3 (structural)
-DeepModel              → Camada 4 (deep)
-AnalysisResult         → Resultado completo de analyze_issue()
-ModelProfile           → Perfil de contexto por modelo LLM
-FlowStep               → Passo no fluxo de interação
-Reference              → Referência seguida pelo orchestrator
-```
+| Backend | Comando | Modelos | Custo | Velocidade |
+|---------|---------|---------|-------|------------|
+| **ollama** | `--llm ollama` | qwen2.5-coder:7b/14b | Grátis (local, CPU/GPU) | ~10-20 min (CPU) |
+| **groq** | `--llm groq` | llama-3.3-70b, llama-4-scout-17b, qwen3-32b | Grátis (rate limit) | ~1-3s |
+| **deepseek** | `--llm deepseek` | deepseek-coder, deepseek-chat | $5 grátis | ~5-15s |
+| **gemini** | `--llm gemini` | gemini-2.5-pro, gemini-2.5-flash | 25-1500 req/dia grátis | ~5-15s |
+
+### Rate limit e fallbacks
+
+| Situação | Comportamento |
+|----------|--------------|
+| **413 (prompt too large)** | Retorna `PROMPT_TOO_LARGE` → run_single retenta sem deep |
+| **429 (rate limit)** | Retry com backoff (parse do tempo de espera) |
+| **Throttling silencioso** | `IAC_LLM_RATE_DELAY` espaça chamadas |
+| **Sem API key** | Erro claro com instrução da variável de ambiente |
+
+## Modos de operação do LLM
+
+| Modo | Prompts | Quando usar | Guardrails |
+|------|---------|-------------|------------|
+| `single` | 1 prompt | Modelos MoE (17B+) | Ajuste progressivo (413 → sem deep) |
+| `multi` | 3 fixos | Modelos 8B — mais estável | Parse rejeita expressões complexas |
+| `loop` | Iterativo | Modelos 14B+ | min_iterations, repair prompt, taxonomia |
+| `auto` | Detecta | Default | small→multi, medium/large→loop |
+
+### Guardrails do loop
+
+| Guardrail | O que faz |
+|-----------|-----------|
+| `_detect_action()` tolerante | Reconhece CLASSIFICAR com markdown, sozinho, por seções |
+| `min_iterations=2` | Impede classificação prematura na 1ª iteração |
+| `normalize_to_known()` | Mapeia labels fora do catálogo (ex: avaliacao-nao-disponivel → prazo-expirado) |
+| Repair prompt | Se resposta tem análise mas não classificou, pede só CLASSIFICAÇÃO |
+| `_enrich_on_repeat()` | Máximo 4 métodos focais quando LLM repete investigação |
+
+### Taxonomia
+
+Labels conhecidos (`KNOWN_TIPOS`): `bug`, `configuracao`, `dados-cadastrais`, `prazo-expirado`, `nao-e-erro`.
+
+Aliases (`_LABEL_ALIASES`): labels criativos do LLM são normalizados para o catálogo:
+- `avaliacao-nao-disponivel` → `prazo-expirado`
+- `logica-incorreta` → `bug`
+- `acesso-negado` → `permissao`
 
 ## Tipos de aresta no grafo
 
@@ -178,103 +244,76 @@ Reference              → Referência seguida pelo orchestrator
 
 ## Perfis de contexto por modelo LLM
 
-| Perfil | Modelos | Prompt | Profundidade FK | Métodos |
-|--------|---------|--------|----------------|---------|
-| `small` | 7B (qwen2.5:7b) | ~10K chars | 2 níveis | Apenas nomes |
-| `medium` | 14-32B | ~20K chars | 2 níveis | Com código |
-| `large` | 70B+ / APIs (Gemini, GPT) | ~28K chars | 3 níveis | Com código |
+| Perfil | Modelos | Deep | Profundidade FK | Métodos |
+|--------|---------|------|----------------|---------|
+| `small` | ≤8B (qwen:7b, llama:8b) | Omitido no single | 2 níveis | Apenas nomes |
+| `medium` | 9-35B (qwen:14b, qwen3:32b) | Incluído | 2 níveis | Com código |
+| `large` | 36B+ / APIs (70b, Gemini, GPT) | Incluído | 3 níveis | Com código |
 
 Detecção automática pelo nome do modelo via `get_model_profile()`.
 
-## Modos de operação do LLM
+## Cenários testados — Groq (issue #57)
 
-| Modo | Módulo | Contexto enviado | Quando usar |
-|------|--------|------------------|-------------|
-| `single` | `runner.py` | 1 prompt com tudo: structural + view + refs + deep (constantes + código dos métodos) | Modelos 14B+ que suportam contexto grande (~20K chars) |
-| `multi` | `runner.py` | 3 prompts fixos: investigação → análise com evidência → resposta | Modelos 7B — mais estável e previsível |
-| `loop` | `loop.py` | Prompt base + iterações incrementais — LLM decide ações (INVESTIGAR, VERIFICAR_BANCO, CLASSIFICAR) | Modelos 14B+ — LLM decide quando parar (max 4 iterações) |
-| `auto` | — | small (7B) → `multi`, medium/large (14B+) → `loop` | Default — seleciona pelo perfil do modelo |
+Issue de teste: [gitlab#16118](https://gitlab.ifrn.edu.br/cosinf/suap/-/work_items/16118) — Erro 9645 - Progressão Docente.
+Classificação esperada: `tipo::nao-e-erro / tipo::prazo-expirado`.
 
-`--mode auto` detecta o tamanho do modelo e seleciona o modo mais adequado:
-- **7B (small):** `multi` — 3 prompts fixos, resultados mais estáveis
-- **14B+ (medium/large):** `loop` — LLM com mais capacidade decide o que investigar
+| Modelo | single | multi | loop | Melhor modo |
+|--------|--------|-------|------|-------------|
+| **llama-3.1-8b** | tipo::bug ❌ | **tipo::nao-e-erro ✅** | ⚠️ parcial | **multi** |
+| **llama-4-scout-17b** | **tipo::nao-e-erro / prazo-expirado ✅✅** | tipo::bug ❌ | ⚠️ parcial | **single** |
+| **qwen3-32b** | 413 ❌ | tipo::bug ❌ | None ❌ | nenhum (rate limit) |
+| **llama-3.3-70b** | 413 ❌ | **tipo::nao-e-erro ✅** | ⚠️ parcial | **multi** |
 
-### Modo loop — ações tipadas
+Padrão emergente:
+- **8B:** multi é o melhor modo
+- **17B MoE (Llama 4):** single funciona — MoE foca melhor
+- **70B:** multi é o melhor modo (single bate em rate limit)
+- **loop:** promissor em todos, labels fora do catálogo
 
-O LLM responde com uma ação por iteração:
-
-| Ação | O que faz | Encerra loop? |
-|------|-----------|---------------|
-| `INVESTIGAR` | Pede mais código → resolve via tools | Não |
-| `VERIFICAR_BANCO` | Pede simulação no banco ([#44](https://github.com/jailtoncarlos/incident-analyst-agent/issues/44)) | Não |
-| `ALTERAR_CODIGO` | Sugere diff (antes/depois) | Não |
-| `CLASSIFICAR` | Análise final + tipo + resolução | **Sim** |
-
-Controles: max 4 iterações, detecção de repetição, forçar CLASSIFICAR na última iteração.
-
-## Estratégia de prompts
-
-Os prompts usam **orientações**, não templates rígidos — o LLM adapta a resposta ao contexto.
-
-**Classificação flexível:** o LLM classifica com `tipo::nome`. Exemplos comuns: `bug`, `configuracao`, `dados-cadastrais`, `prazo-expirado`, `nao-e-erro`. Pode criar labels novos se nenhum se aplica (ex: `tipo::permissao`).
-
-**Correlação descrição ↔ código:** os prompts orientam o LLM a correlacionar a descrição do usuário com constantes e campos do código (ex: "tempo hábil" → `TEMPO_AVALIACAO = 10`).
-
-**Plano de verificação:** o LLM indica o que verificar no banco e como admin para confirmar a hipótese.
-
-**Fluxo com verificação no banco** ([#44](https://github.com/jailtoncarlos/incident-analyst-agent/issues/44)):
-
-```
-Prompt 1 (investigação)       → LLM pede código
-Prompt 2 (análise parcial)    → LLM analisa + sugere VERIFICAR_BANCO
-  ↓ Simulator (banco mascarado)
-Prompt 3 (análise final)      → LLM recebe resultado + classifica
-Prompt 4 (resposta)           → LLM gera rascunho adaptado ao tipo
-```
+Detalhes: [issue #15](https://github.com/jailtoncarlos/incident-analyst-agent/issues/15) (Ollama), [issue #57](https://github.com/jailtoncarlos/incident-analyst-agent/issues/57) (Groq).
 
 ## Logging
 
-Formato por camada, gravado em `.iac/logs/iac.log` (DEBUG) e terminal (INFO):
+Formato por camada, gravado em `.iac/logs/iac_YYYYMMDD_HHMMSS.log` (DEBUG) e terminal (INFO):
 
 ```
 [Camada 1] Classifier — origem=erro-suap, app=progressao_docente
-[Camada 2] Orchestrator — 12 calls, 1 refs, 10 passos
+[Camada 2] Orchestrator — 12 calls, 2 refs, 13 passos
 [Camada 3] Structural — 2 models, 1 templates, 6 passos no fluxo
-[Camada 4] Deep — 6 models em profundidade
-[LLM] Prompt 1 (investigação): 4041 chars → enviando ao ollama
-[LLM] send_to_llm: 1014 chars em 114.9s
-[LLM] Resposta 1 (investigação): 1014 chars
-[LLM] Evidência resolvida: 1912 chars
-[LLM] Prompt 2 (análise): 6096 chars
-[LLM] send_to_llm: 2310 chars em 214.5s
-[Resultado] Classificação: tipo::prazo-expirado
+[Camada 4] Deep — 11 models em profundidade
+[LLM] Rate delay: 30s
+[LLM] Modo single-prompt: 5740 chars (deep=False) → enviando ao groq
+[LLM] send_to_llm: 1722 chars em 1.4s
+[Resultado] Classificação: tipo=tipo::nao-e-erro, subtipo=tipo::prazo-expirado
 ```
-
-## Cenários testados — issue [#16118](https://gitlab.ifrn.edu.br/cosinf/suap/-/work_items/16118)
-
-Classificação esperada: `tipo::prazo-expirado` (prazo de 10 dias para avaliação discente expirou).
-
-| Modelo | Modo | Classificação | Acertou? | Observação |
-|--------|------|---------------|----------|------------|
-| qwen2.5:7b | single | `tipo::bug` | ❌ | Não correlacionou "tempo hábil" com constante |
-| qwen2.5:7b | multi | `tipo::bug` | ❌ | Evidência insuficiente (381 chars) |
-| qwen2.5-coder:7b | multi | `tipo::nao-e-erro` | ❌ | Reconheceu filtro mas não correlacionou prazo |
-| **qwen2.5-coder:7b** | **multi** | **`tipo::prazo-expirado`** | **✅** | Prompts com orientação + evidência focal |
-| qwen2.5-coder:7b | loop v1 | `Bug::Avaliação Não Preenchida` | ❌ | Confundiu TEMPO_PREENCHIMENTO com TEMPO_AVALIACAO |
-| qwen2.5-coder:7b | loop v2 | `tipo::permissao-nao-autorizada` | ❌ | Foi direto para CLASSIFICAR sem investigar |
-| qwen2.5:14b | single | — | ⏳ | A testar — prompt completo (~20K chars) |
-| qwen2.5:14b | multi | — | ⏳ | A testar |
-| qwen2.5:14b | loop | — | ⏳ | A testar — auto seleciona este |
-
-Detalhes de cada execução: [issue #15](https://github.com/jailtoncarlos/incident-analyst-agent/issues/15).
-
-Nota: modelos 7B são não-determinísticos — mesma entrada pode dar resultados diferentes entre execuções. Por isso, `auto` usa `multi` para 7B (mais estável) e `loop` para 14B+ (mais capaz).
 
 ## Qualidade de código
 
 - **Lint:** `ruff` com 11 categorias de regras (E, F, W, I, N, UP, S, B, SIM, PIE, D)
 - **Docstrings:** Google convention obrigatória (`pydocstyle`)
 - **Tamanho de módulo:** `pylint` com `max-module-lines=400` (`.pylintrc`)
-- **Testes:** 106 testes unitários + fixtures determinísticos
+- **Testes:** 153 testes (unitários + integração + regressão)
 - **CI:** GitHub Actions (ruff + pylint + pytest em cada push)
 - **Pre-commit:** `ruff-format` + `ruff check` + `pylint` (tamanho de módulo)
+
+## Milestones
+
+| Milestone | Estado | Issues |
+|-----------|--------|--------|
+| [v0.1 — Inspeção e Análise](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/1) | ✅ fechada | 18 fechadas |
+| [v0.2 — Qualidade da Análise LLM](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/3) | em aberto | #7, #39, #50, #52, #53, #54 |
+| [v0.3 — Simulação e Verificação](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/4) | em aberto | #4, #6, #8, #44, #59, #60 |
+| [v0.4 — Aprendizado (RAG)](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/5) | em aberto | #55 |
+| [v1.0 — Chatbot Conversacional](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/6) | em aberto | #56 |
+| [Casos de Teste](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/7) | em aberto | #14-32, #40 |
+
+## Evolução planejada
+
+```
+Atual:  Inspeção direta + LLM (4 backends, 4 modos, guardrails)
+v0.2:   Melhorar análise LLM (loop fechamento, multi parse, taxonomia)
+v0.3:   + Simulação no banco (#44) + Relatório unificado (#60)
+v0.4:   + RAG com 8.398 issues do SUAP (#55)
+v1.0:   + Chatbot conversacional (#56)
+Futuro: + Fine-tuning / DPO quando dataset suficiente (#55)
+```

--- a/src/iac/agent/loop.py
+++ b/src/iac/agent/loop.py
@@ -14,7 +14,7 @@ import re
 
 from iac.agent.format import format_context_for_prompt
 from iac.agent.prompts.multi import parse_investigation_requests, resolve_investigation_requests
-from iac.agent.prompts.utils import extract_tipo_from_analysis
+from iac.agent.prompts.utils import KNOWN_TIPOS, extract_tipo_from_analysis, normalize_to_known
 from iac.agent.runner import send_to_llm
 from iac.agent.structural import format_structural_analysis
 
@@ -81,6 +81,19 @@ PROMPT_HISTORY_EMPTY = "Esta é a primeira iteração. Analise o código da view
 
 PROMPT_HISTORY_PREFIX = "## Histórico — o que já foi investigado (NÃO repita)\n\n"
 
+PROMPT_REPAIR = """Sua resposta anterior contém análise mas falta a classificação no formato esperado.
+
+Responda APENAS com:
+
+CLASSIFICAÇÃO: tipo::label-principal
+SUBCLASSIFICAÇÃO: tipo::motivo-especifico
+
+Labels válidos: bug, configuracao, dados-cadastrais, prazo-expirado, nao-e-erro, permissao.
+Se nenhum se aplica, crie um descritivo em kebab-case.
+
+Sua análise anterior:
+{analysis_snippet}"""
+
 
 def run_loop(
     result: dict,
@@ -92,27 +105,13 @@ def run_loop(
     llm_url: str | None,
     llm_key: str | None,
     max_iterations: int = 4,
+    min_iterations: int = 2,
     initial_history: str | None = None,
 ) -> dict:
     """Executa loop interativo de análise.
 
     O LLM decide a cada iteração se precisa de mais informação ou se
     pode concluir. Retorna quando recebe CLASSIFICAR ou atinge max_iterations.
-
-    Args:
-        result: Dict retornado por analyze_issue().
-        structure: Mapa estrutural (.iac/structure.json).
-        graph: Grafo de dependências (.iac/graph.json).
-        base_dir: Diretório raiz do projeto.
-        llm: Backend LLM.
-        llm_model: Nome do modelo.
-        llm_url: Endpoint da API.
-        llm_key: API key.
-        max_iterations: Máximo de iterações do loop.
-        initial_history: Histórico inicial (ex: análise do single como Prompt 0).
-
-    Returns:
-        Dict com analysis (texto), tipo, alteracoes, iterations.
     """
     # Contexto base (não muda entre iterações)
     structural_text = format_structural_analysis(result['structural'])
@@ -175,8 +174,31 @@ def run_loop(
         logger.info(f'[Loop iteração {iteration}] Ação: {action}')
 
         if action == 'CLASSIFICAR':
+            tipo_candidate = extract_tipo_from_analysis(response)
+
+            # Impedir classificação prematura (antes de min_iterations)
+            if iteration < min_iterations and not force_classify:
+                logger.info(f'[Loop iteração {iteration}] CLASSIFICAR prematuro (min_iterations={min_iterations}) — forçando investigação')
+                history_entries.append(
+                    f'**Iteração {iteration} — CLASSIFICAR prematuro**\n\n'
+                    f'Você classificou como `{tipo_candidate}`, mas ainda não investigou o suficiente.\n'
+                    f'Use INVESTIGAR para buscar constantes temporais (ex: TEMPO_AVALIACAO) e métodos relacionados antes de concluir.'
+                )
+                continue
+
+            # Validar taxonomia — normalizar label se fora do catálogo
+            if tipo_candidate and tipo_candidate not in KNOWN_TIPOS:
+                normalized = normalize_to_known(tipo_candidate)
+                if normalized:
+                    logger.info(f'[Loop] Label normalizado: {tipo_candidate} → {normalized}')
+                    tipo_candidate = normalized
+
+            # Se não extraiu tipo, tentar repair prompt
+            if not tipo_candidate:
+                tipo_candidate = _repair_classification(response, llm, llm_model, llm_url, llm_key)
+
             final_analysis = response
-            final_tipo = extract_tipo_from_analysis(response)
+            final_tipo = tipo_candidate
             logger.info(f'[Loop] Classificação final: {final_tipo}')
             break
 
@@ -228,7 +250,13 @@ def run_loop(
         else:
             # Ação não reconhecida — tentar extrair classificação mesmo assim
             tipo = extract_tipo_from_analysis(response)
+            if not tipo:
+                tipo = _repair_classification(response, llm, llm_model, llm_url, llm_key)
             if tipo:
+                if tipo not in KNOWN_TIPOS:
+                    normalized = normalize_to_known(tipo)
+                    if normalized:
+                        tipo = normalized
                 final_analysis = response
                 final_tipo = tipo
                 logger.info(f'[Loop] Classificação implícita: {final_tipo}')
@@ -258,19 +286,27 @@ def _detect_action(response: str) -> str:
     Returns:
         'CLASSIFICAR', 'INVESTIGAR', 'VERIFICAR_BANCO', 'ALTERAR_CODIGO' ou 'DESCONHECIDO'.
     """
+    clean = response.replace('**', '').replace('`', '')
+
     # Procurar AÇÃO: explícita
-    match = re.search(r'AÇÃO:\s*(CLASSIFICAR|INVESTIGAR|VERIFICAR_BANCO|ALTERAR_CODIGO)', response)
+    match = re.search(r'AÇÃO:\s*(CLASSIFICAR|INVESTIGAR|VERIFICAR_BANCO|ALTERAR_CODIGO)', clean)
     if match:
         return match.group(1)
 
     # Inferir pela presença de marcadores
-    if 'CLASSIFICAÇÃO:' in response or 'tipo::' in response:
+    if 'CLASSIFICAÇÃO:' in clean or 'CLASSIFICACAO:' in clean or 'tipo::' in clean:
         return 'CLASSIFICAR'
-    if 'INVESTIGAR:' in response:
+    # CLASSIFICAR sozinho (com ou sem markdown)
+    if re.search(r'^\s*CLASSIFICAR\s*$', clean, re.MULTILINE):
+        return 'CLASSIFICAR'
+    # Seções finais presentes → classificação implícita
+    if '### Análise' in response and '### Resolução' in response:
+        return 'CLASSIFICAR'
+    if 'INVESTIGAR:' in clean:
         return 'INVESTIGAR'
-    if 'VERIFICAR_BANCO' in response or 'CONSULTA:' in response:
+    if 'VERIFICAR_BANCO' in clean or 'CONSULTA:' in clean:
         return 'VERIFICAR_BANCO'
-    if 'ALTERAR_CODIGO' in response or 'ANTES:' in response:
+    if 'ALTERAR_CODIGO' in clean or 'ANTES:' in clean:
         return 'ALTERAR_CODIGO'
 
     return 'DESCONHECIDO'
@@ -288,17 +324,7 @@ def _request_key(req: dict) -> str:
 
 
 def _enrich_on_repeat(req: dict, structure: dict, graph: dict, base_dir) -> str:
-    """Enriquece com métodos relacionados quando LLM repete investigação.
-
-    Args:
-        req: Pedido repetido.
-        structure: Mapa estrutural.
-        graph: Grafo de dependências.
-        base_dir: Diretório raiz.
-
-    Returns:
-        Texto com métodos/propriedades relacionados à constante investigada.
-    """
+    """Enriquece com métodos relacionados quando LLM repete investigação."""
     from pathlib import Path
 
     from iac.agent.tools import ler_funcao
@@ -315,16 +341,34 @@ def _enrich_on_repeat(req: dict, structure: dict, graph: dict, base_dir) -> str:
     methods = model_data.get('methods', {})
     loc_file = model_data.get('file', '')
 
-    # Buscar métodos cujo nome contenha a constante pedida
+    # Buscar métodos cujo nome contenha a constante pedida (limitar a 4)
+    found = 0
     for m_name, m_info in methods.items():
+        if found >= 4:
+            break
         if requested.lower().replace('tempo_', '') in m_name.lower():
             m_line = m_info.get('line')
             if m_line and loc_file:
                 src = ler_funcao(loc_file, m_line, Path(base_dir), max_lines=10)
                 if src:
                     sections.append(f'**`{model_name}.{m_name}`** (linha {m_line}):\n```python\n{src}\n```')
+                    found += 1
 
     return '\n'.join(sections)
+
+
+def _repair_classification(response: str, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None) -> str | None:
+    """Tenta extrair classificação via repair prompt curto."""
+    snippet = response[:1500]
+    prompt = PROMPT_REPAIR.format(analysis_snippet=snippet)
+    logger.info(f'[Loop] Repair prompt: {len(prompt)} chars → enviando ao {llm}')
+    repair_response = send_to_llm(prompt, llm, llm_model, llm_url, llm_key)
+    if not repair_response:
+        return None
+    tipo = extract_tipo_from_analysis(repair_response)
+    if tipo:
+        logger.info(f'[Loop] Repair extraiu: {tipo}')
+    return tipo
 
 
 def _extract_consulta(response: str) -> str:

--- a/src/iac/agent/orchestrator.py
+++ b/src/iac/agent/orchestrator.py
@@ -56,7 +56,7 @@ def get_model_profile(model_name: str | None) -> dict:
 
     name = model_name.lower()
 
-    if any(api in name for api in ('gemini', 'gpt', 'claude', 'sonnet', 'opus')):
+    if any(api in name for api in ('gemini', 'gpt', 'claude', 'sonnet', 'opus', 'groq')):
         return MODEL_PROFILES['large']
 
     size_match = re.search(r':?(\d+)[bB]', name)

--- a/src/iac/agent/prompts/__init__.py
+++ b/src/iac/agent/prompts/__init__.py
@@ -21,4 +21,5 @@ from iac.agent.prompts.utils import (  # noqa: F401
     compact_code,
     extract_classificacao,
     extract_tipo_from_analysis,
+    normalize_to_known,
 )

--- a/src/iac/agent/prompts/analysis.py
+++ b/src/iac/agent/prompts/analysis.py
@@ -66,11 +66,12 @@ REGRAS:
 - Correlacione sempre a descrição do usuário com o código analisado"""
 
 
-def build_analysis_prompt(result: dict) -> str:
+def build_analysis_prompt(result: dict, include_deep: bool = True) -> str:
     """Constrói o prompt de análise completo (modo single-prompt).
 
     Args:
         result: Dict retornado por analyze_issue() com structural, context e deep.
+        include_deep: Se False, omite a análise profunda do prompt (útil para modelos pequenos).
 
     Returns:
         Prompt completo para enviar ao LLM.
@@ -86,12 +87,13 @@ def build_analysis_prompt(result: dict) -> str:
         sections.append('\n---\n')
         sections.append(context_text)
 
-    deep = result.get('deep', [])
-    if deep:
-        deep_text = format_deep_analysis(deep)
-        if deep_text.strip():
-            sections.append('\n---\n')
-            sections.append(deep_text)
+    if include_deep:
+        deep = result.get('deep', [])
+        if deep:
+            deep_text = format_deep_analysis(deep)
+            if deep_text.strip():
+                sections.append('\n---\n')
+                sections.append(deep_text)
 
     sections.append('\n---\n')
     sections.append(TEMPLATE_ANALYSIS)

--- a/src/iac/agent/prompts/multi.py
+++ b/src/iac/agent/prompts/multi.py
@@ -132,6 +132,14 @@ def parse_investigation_requests(llm_response: str) -> list[dict]:
         if '/templates/' in target or target.endswith('.html'):
             logger.debug(f'Pedido ignorado (template): {target}')
             continue
+        # Rejeitar expressões encadeadas (request.user.get_relacionamento().matricula)
+        if '()' in target or target.count('.') > 4:
+            logger.debug(f'Pedido ignorado (expressão complexa): {target}')
+            continue
+        # Rejeitar query fragments (Model.filter(...), Model.objects.get(...))
+        if re.search(r'\.(filter|objects|get|exclude|annotate|aggregate)\b', target):
+            logger.debug(f'Pedido ignorado (query fragment): {target}')
+            continue
 
         parts = target.split('.')
         if len(parts) >= 4 and parts[1] == 'models':

--- a/src/iac/agent/prompts/response.py
+++ b/src/iac/agent/prompts/response.py
@@ -1,29 +1,30 @@
-"""Prompt de resposta ao usuário — rascunho para revisão humana."""
+"""Prompt de resposta — relatório técnico para o desenvolvedor."""
 
 from __future__ import annotations
 
 from iac.agent.prompts.utils import extract_tipo_from_analysis
 
-PROMPT_RESPONSE = """Você é um atendente técnico do SUAP (Sistema Unificado de Administração Pública) \
-respondendo a um usuário que reportou um problema.
+PROMPT_RESPONSE = """Você é um engenheiro de software sênior do SUAP (ERP Django) \
+produzindo um relatório técnico sobre um incidente reportado.
 
-Com base na análise técnica abaixo, gere um rascunho de resposta ao usuário.
+Com base na análise abaixo, gere um relatório conciso para o desenvolvedor que vai tratar o chamado.
 
 ## Orientações
 
-- Comece com "Prezado(a) {nome},"
-- Tom formal e respeitoso
-- NUNCA culpe o usuário
-- Explique o que foi identificado em linguagem acessível (sem jargão de código)
-- Se for bug: reconheça que o usuário estava correto e informe que a correção será aplicada
-- Se for configuração/dados: explique o que precisa ser ajustado e por quem (coordenador, secretaria, admin)
-- Se for prazo expirado: explique o prazo do sistema e oriente sobre próximos passos
-- Se não é erro: explique o comportamento esperado do sistema de forma clara
-- Inclua orientação concreta: quem procurar, o que fazer, passos específicos
-- Encerre com "Caso a dúvida persista, estamos à disposição."
-- O texto deve ser precedido por "resolvido:" na primeira linha
-- Use blocos de citação (>) para o corpo da resposta
-- Mantenha entre 3 e 6 parágrafos
+- Escreva para um desenvolvedor, não para o usuário final
+- Use linguagem técnica (nomes de models, views, constantes, campos)
+- Estruture em seções claras:
+  1. **Resumo** — o que foi reportado e classificação
+  2. **Diagnóstico** — causa raiz identificada com referências ao código (arquivo:linha)
+  3. **Evidências** — constantes, campos e métodos relevantes encontrados
+  4. **Ação recomendada** — o que fazer para resolver
+     - Se bug: descreva o fix necessário (arquivo, método, lógica)
+     - Se configuração/dados: descreva a ação administrativa (admin, shell, SQL)
+     - Se prazo expirado: descreva o prazo do sistema e se cabe reabertura
+     - Se não é erro: explique o comportamento esperado
+  5. **Verificação** — como confirmar que o diagnóstico está correto
+- Marque com [ENCONTRADO] evidências no código e [INFERÊNCIA] hipóteses
+- Seja conciso — máximo 20 linhas
 
 ## Dados do incidente
 

--- a/src/iac/agent/prompts/utils.py
+++ b/src/iac/agent/prompts/utils.py
@@ -115,6 +115,33 @@ def extract_classificacao(analysis: str) -> dict:
     }
 
 
+# Mapeamento de labels comuns fora do catálogo → label conhecido
+_LABEL_ALIASES = {
+    'tipo::avaliacao-nao-disponivel': 'tipo::prazo-expirado',
+    'tipo::prazo-avaliacao': 'tipo::prazo-expirado',
+    'tipo::tempo-expirado': 'tipo::prazo-expirado',
+    'tipo::tempo-esgotado': 'tipo::prazo-expirado',
+    'tipo::validacao-falhada': 'tipo::bug',
+    'tipo::logica-incorreta': 'tipo::bug',
+    'tipo::excecao-nao-tratada': 'tipo::bug',
+    'tipo::erro-de-codigo': 'tipo::bug',
+    'tipo::acesso-negado': 'tipo::permissao',
+    'tipo::sem-permissao': 'tipo::permissao',
+}
+
+
+def normalize_to_known(tipo: str) -> str | None:
+    """Normaliza label fora do catálogo para o mais próximo conhecido.
+
+    Args:
+        tipo: Label tipo::* fora de KNOWN_TIPOS.
+
+    Returns:
+        Label conhecido ou None se não houver mapeamento.
+    """
+    return _LABEL_ALIASES.get(tipo)
+
+
 def compact_code(source: str) -> str:
     """Compacta código removendo docstrings, comentários e linhas em branco.
 

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -50,7 +50,10 @@ def send_to_llm(prompt: str, llm: str, llm_model: str, llm_url: str | None, llm_
             return None
         result = gemini.chat(prompt, url=llm_url, api_key=llm_key)
     elapsed = time.time() - t0
-    logger.info(f'[LLM] send_to_llm: {len(result or "")} chars em {elapsed:.1f}s')
+    if result:
+        logger.info(f'[LLM] send_to_llm: {len(result)} chars em {elapsed:.1f}s')
+    else:
+        logger.warning(f'[LLM] send_to_llm: sem resposta em {elapsed:.1f}s (possível timeout ou erro de conexão)')
     return result
 
 

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -44,6 +44,10 @@ def send_to_llm(prompt: str, llm: str, llm_model: str, llm_url: str | None, llm_
         from iac.integrations import ollama
         url = llm_url or 'http://localhost:11434/v1/chat/completions'
         result = ollama.chat(prompt, url=url, model=llm_model, api_key=llm_key)
+    elif llm == 'groq':
+        from iac.integrations import groq
+        url = llm_url or groq.DEFAULT_URL
+        result = groq.chat(prompt, url=url, model=llm_model, api_key=llm_key)
     elif llm == 'gemini':
         from iac.integrations import gemini
         if not llm_url or not llm_key:

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -62,6 +62,9 @@ def send_to_llm(prompt: str, llm: str, llm_model: str, llm_url: str | None, llm_
             return None
         result = gemini.chat(prompt, url=llm_url, api_key=llm_key)
     elapsed = time.time() - t0
+    if result == 'PROMPT_TOO_LARGE':
+        logger.warning(f'[LLM] send_to_llm: prompt muito grande em {elapsed:.1f}s')
+        return 'PROMPT_TOO_LARGE'
     if result:
         logger.info(f'[LLM] send_to_llm: {len(result)} chars em {elapsed:.1f}s')
     else:
@@ -70,27 +73,30 @@ def send_to_llm(prompt: str, llm: str, llm_model: str, llm_url: str | None, llm_
 
 
 def run_single(result: dict, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None) -> str | None:
-    """Executa análise em modo single-prompt.
+    """Executa análise em modo single-prompt com ajuste progressivo.
 
-    Args:
-        result: Dict retornado por analyze_issue().
-        llm: Backend LLM.
-        llm_model: Nome do modelo.
-        llm_url: Endpoint da API.
-        llm_key: API key.
-
-    Returns:
-        Texto da análise do LLM ou None.
+    Se o prompt for grande demais (413), reduz progressivamente:
+    1. Com deep → 2. Sem deep → 3. Desiste.
     """
     profile = get_model_profile(llm_model)
     include_deep = profile.get('deep_include_methods', True)
     prompt = build_analysis_prompt(result, include_deep=include_deep)
     logger.info(f'[LLM] Modo single-prompt: {len(prompt)} chars (deep={include_deep}) → enviando ao {llm} ({llm_model})')
-    logger.debug(f'[LLM] Prompt (single) conteúdo:\n{prompt}')
 
     analysis = send_to_llm(prompt, llm, llm_model, llm_url, llm_key)
+
+    # Ajuste progressivo: se prompt grande demais, reduzir
+    if analysis == 'PROMPT_TOO_LARGE' and include_deep:
+        logger.info('[LLM] Prompt muito grande — retentando sem deep')
+        prompt = build_analysis_prompt(result, include_deep=False)
+        logger.info(f'[LLM] Modo single-prompt (sem deep): {len(prompt)} chars → enviando ao {llm} ({llm_model})')
+        analysis = send_to_llm(prompt, llm, llm_model, llm_url, llm_key)
+
+    if analysis == 'PROMPT_TOO_LARGE':
+        logger.error('[LLM] Prompt ainda muito grande mesmo sem deep — modelo não suporta este tamanho')
+        return None
+
     logger.info(f'[LLM] Resposta (single): {len(analysis or "")} chars')
-    logger.debug(f'[LLM] Resposta (single) conteúdo:\n{analysis}')
     return analysis
 
 

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -10,6 +10,7 @@ import logging
 import time
 
 from iac.agent.format import format_context_for_prompt
+from iac.agent.orchestrator import get_model_profile
 from iac.agent.prompts import (
     _strip_context_header,
     build_analysis_prompt,
@@ -70,8 +71,10 @@ def run_single(result: dict, llm: str, llm_model: str, llm_url: str | None, llm_
     Returns:
         Texto da análise do LLM ou None.
     """
-    prompt = build_analysis_prompt(result)
-    logger.info(f'[LLM] Modo single-prompt: {len(prompt)} chars → enviando ao {llm} ({llm_model})')
+    profile = get_model_profile(llm_model)
+    include_deep = profile.get('deep_include_methods', True)
+    prompt = build_analysis_prompt(result, include_deep=include_deep)
+    logger.info(f'[LLM] Modo single-prompt: {len(prompt)} chars (deep={include_deep}) → enviando ao {llm} ({llm_model})')
     logger.debug(f'[LLM] Prompt (single) conteúdo:\n{prompt}')
 
     analysis = send_to_llm(prompt, llm, llm_model, llm_url, llm_key)

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -51,6 +51,10 @@ def send_to_llm(prompt: str, llm: str, llm_model: str, llm_url: str | None, llm_
         from iac.integrations import groq
         url = llm_url or groq.DEFAULT_URL
         result = groq.chat(prompt, url=url, model=llm_model, api_key=llm_key)
+    elif llm == 'deepseek':
+        from iac.integrations import deepseek
+        url = llm_url or deepseek.DEFAULT_URL
+        result = deepseek.chat(prompt, url=url, model=llm_model, api_key=llm_key)
     elif llm == 'gemini':
         from iac.integrations import gemini
         if not llm_url or not llm_key:

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -7,6 +7,7 @@ Encapsula a lógica de envio de prompts e processamento de respostas.
 from __future__ import annotations
 
 import logging
+import os
 import time
 
 from iac.agent.format import format_context_for_prompt
@@ -25,19 +26,21 @@ from iac.agent.prompts import (
 logger = logging.getLogger(__name__)
 
 
+_LLM_RATE_DELAY = int(os.environ.get('IAC_LLM_RATE_DELAY', '0'))
+_LLM_MAX_RETRIES = int(os.environ.get('IAC_LLM_MAX_RETRIES', '3'))
+
+
 def send_to_llm(prompt: str, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None) -> str | None:
     """Envia prompt ao backend LLM configurado.
 
-    Args:
-        prompt: Texto do prompt.
-        llm: Backend ('ollama' ou 'gemini').
-        llm_model: Nome do modelo.
-        llm_url: Endpoint da API.
-        llm_key: API key.
-
-    Returns:
-        Texto da resposta ou None.
+    Rate delay e retries são controlados por variáveis de ambiente:
+        IAC_LLM_RATE_DELAY — delay em segundos entre chamadas (default: 0)
+        IAC_LLM_MAX_RETRIES — máximo de retries (default: 3)
     """
+    if _LLM_RATE_DELAY > 0 and llm != 'ollama':
+        logger.debug(f'[LLM] Rate delay: {_LLM_RATE_DELAY}s')
+        time.sleep(_LLM_RATE_DELAY)
+
     t0 = time.time()
     result = None
     if llm == 'ollama':

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -82,12 +82,12 @@ def init(base_dir: str, force: bool, stats: bool):
 @click.option('--title', type=str, default=None, help='Título do incidente.')
 @click.option('--description', type=str, default=None, help='Descrição do incidente.')
 @click.option('--base-dir', type=click.Path(exists=True), default='.', help='Diretório raiz do projeto.')
-@click.option('--llm', type=click.Choice(['ollama', 'groq', 'gemini']), default=None, help='Backend LLM.')
-@click.option('--llm-url', type=str, default=None, help='Endpoint do LLM.')
-@click.option('--llm-key', type=str, default=None, help='API key do LLM.')
-@click.option('--llm-model', type=str, default=None, help='Modelo do LLM (default: config.yaml ou qwen2.5:7b).')
-@click.option('--gitlab-token', type=str, envvar='GITLAB_TOKEN', default=None, help='Token GitLab.')
-@click.option('--mode', type=click.Choice(['auto', 'single', 'multi', 'loop']), default='auto', help='Modo: auto, single (1 prompt), multi (3 prompts fixos), loop (iterativo, LLM decide).')
+@click.option('--llm', type=click.Choice(['ollama', 'groq', 'gemini']), envvar='IAC_LLM_BACKEND', default=None, help='Backend LLM (env: IAC_LLM_BACKEND).')
+@click.option('--llm-url', type=str, envvar='IAC_LLM_URL', default=None, help='Endpoint do LLM (env: IAC_LLM_URL).')
+@click.option('--llm-key', type=str, default=None, help='API key do LLM (env: GROQ_API_KEY, GEMINI_API_KEY).')
+@click.option('--llm-model', type=str, envvar='IAC_LLM_MODEL', default=None, help='Modelo do LLM (env: IAC_LLM_MODEL).')
+@click.option('--gitlab-token', type=str, envvar='GITLAB_TOKEN', default=None, help='Token GitLab (env: GITLAB_TOKEN).')
+@click.option('--mode', type=click.Choice(['auto', 'single', 'multi', 'loop']), envvar='IAC_ANALYZE_MODE', default=None, help='Modo (env: IAC_ANALYZE_MODE).')
 @click.option('--env-file', type=click.Path(), default=None, help='Caminho para .env (default: .iac/.env).')
 @click.option('--dry-run', is_flag=True, help='Não posta comentários nem aplica labels.')
 @click.option('--post', is_flag=True, help='Postar análise como comentário na issue.')
@@ -151,15 +151,13 @@ def analyze(
         'gitlab_token': gitlab_token, 'mode': mode,
     })
 
-    # Aplicar config — llm só é ativado se passado via --llm
-    # config.yaml define o default quando --llm é passado, não ativa automaticamente
+    # Resolução: CLI args (já com envvar via click) → config.yaml → defaults
+    llm = llm or cfg['llm'].get('backend')
     llm_model = llm_model or cfg['llm'].get('model') or 'qwen2.5:7b'
-    if llm and not llm_model:
-        llm_model = cfg['llm']['model']
     llm_url = llm_url or cfg['llm'].get('url')
     llm_key = llm_key or cfg['llm'].get('key') or os.environ.get('GROQ_API_KEY') or os.environ.get('GEMINI_API_KEY')
     gitlab_token = gitlab_token or cfg['gitlab'].get('token') or os.environ.get('GITLAB_TOKEN')
-    mode = cfg['analyze'].get('mode', mode)
+    mode = mode or cfg['analyze'].get('mode') or 'auto'
 
     structure = load_structure(iac_dir)
     graph = load_graph(iac_dir)

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -82,7 +82,7 @@ def init(base_dir: str, force: bool, stats: bool):
 @click.option('--title', type=str, default=None, help='Título do incidente.')
 @click.option('--description', type=str, default=None, help='Descrição do incidente.')
 @click.option('--base-dir', type=click.Path(exists=True), default='.', help='Diretório raiz do projeto.')
-@click.option('--llm', type=click.Choice(['ollama', 'groq', 'gemini']), envvar='IAC_LLM_BACKEND', default=None, help='Backend LLM (env: IAC_LLM_BACKEND).')
+@click.option('--llm', type=click.Choice(['ollama', 'groq', 'deepseek', 'gemini']), envvar='IAC_LLM_BACKEND', default=None, help='Backend LLM (env: IAC_LLM_BACKEND).')
 @click.option('--llm-url', type=str, envvar='IAC_LLM_URL', default=None, help='Endpoint do LLM (env: IAC_LLM_URL).')
 @click.option('--llm-key', type=str, default=None, help='API key do LLM (env: GROQ_API_KEY, GEMINI_API_KEY).')
 @click.option('--llm-model', type=str, envvar='IAC_LLM_MODEL', default=None, help='Modelo do LLM (env: IAC_LLM_MODEL).')
@@ -155,7 +155,7 @@ def analyze(
     llm = llm or cfg['llm'].get('backend')
     llm_model = llm_model or cfg['llm'].get('model') or 'qwen2.5:7b'
     llm_url = llm_url or cfg['llm'].get('url')
-    llm_key = llm_key or cfg['llm'].get('key') or os.environ.get('GROQ_API_KEY') or os.environ.get('GEMINI_API_KEY')
+    llm_key = llm_key or cfg['llm'].get('key') or os.environ.get('GROQ_API_KEY') or os.environ.get('DEEPSEEK_API_KEY') or os.environ.get('GEMINI_API_KEY')
     gitlab_token = gitlab_token or cfg['gitlab'].get('token') or os.environ.get('GITLAB_TOKEN')
     mode = mode or cfg['analyze'].get('mode') or 'auto'
 
@@ -199,14 +199,16 @@ def analyze(
 
     # Log dos argumentos de entrada
     # Validar API key para backends que exigem
-    if llm in ('groq', 'gemini') and not llm_key:
-        env_var = 'GROQ_API_KEY' if llm == 'groq' else 'GEMINI_API_KEY'
-        click.echo(f'API key necessária para {llm}. Use --llm-key, {env_var} ou config.yaml.')
+    if llm in ('groq', 'deepseek', 'gemini') and not llm_key:
+        env_vars = {'groq': 'GROQ_API_KEY', 'deepseek': 'DEEPSEEK_API_KEY', 'gemini': 'GEMINI_API_KEY'}
+        click.echo(f'API key necessária para {llm}. Use --llm-key, {env_vars[llm]} ou .iac/.env.')
         sys.exit(1)
 
     # URL default por backend (se não informado)
     if llm == 'groq' and (not llm_url or 'localhost' in llm_url):
         llm_url = 'https://api.groq.com/openai/v1/chat/completions'
+    elif llm == 'deepseek' and (not llm_url or 'localhost' in llm_url):
+        llm_url = 'https://api.deepseek.com/v1/chat/completions'
 
     logger.info('=== iac analyze iniciado ===')
     logger.info(f'Base dir: {base}')

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -81,7 +81,7 @@ def init(base_dir: str, force: bool, stats: bool):
 @click.option('--title', type=str, default=None, help='Título do incidente.')
 @click.option('--description', type=str, default=None, help='Descrição do incidente.')
 @click.option('--base-dir', type=click.Path(exists=True), default='.', help='Diretório raiz do projeto.')
-@click.option('--llm', type=click.Choice(['ollama', 'gemini']), default=None, help='Backend LLM.')
+@click.option('--llm', type=click.Choice(['ollama', 'groq', 'gemini']), default=None, help='Backend LLM.')
 @click.option('--llm-url', type=str, default=None, help='Endpoint do LLM.')
 @click.option('--llm-key', type=str, default=None, help='API key do LLM.')
 @click.option('--llm-model', type=str, default=None, help='Modelo do LLM (default: config.yaml ou qwen2.5:7b).')

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -143,7 +143,7 @@ def analyze(
     # Root logger precisa estar em DEBUG para o FileHandler receber tudo
     root_logger.setLevel(logging.DEBUG)
     from iac.agent.orchestrator import analyze_issue, format_structural_analysis
-    from iac.agent.prompts import extract_tipo_from_analysis
+    from iac.agent.prompts import extract_classificacao
 
     # Configuração efetiva: config.yaml + CLI args
     cfg = get_effective_config(iac_dir, {
@@ -280,14 +280,22 @@ def analyze(
         click.echo('\n--- Análise do LLM ---\n')
         click.echo(llm_analysis)
 
-        tipo = loop_result.get('tipo') if loop_result else extract_tipo_from_analysis(llm_analysis)
+        classificacao = extract_classificacao(llm_analysis)
+        tipo = loop_result.get('tipo') if loop_result else classificacao['classificacao']
+        subtipo = classificacao.get('subclassificacao')
+
         if tipo:
             click.echo(f'\nClassificação: {tipo}')
             result['classification']['tipo_sugerido'] = tipo
             if tipo not in result['classification']['labels_sugeridos']:
                 result['classification']['labels_sugeridos'].append(tipo)
+        if subtipo:
+            click.echo(f'Subclassificação: {subtipo}')
+            result['classification']['subtipo_sugerido'] = subtipo
+            if subtipo not in result['classification']['labels_sugeridos']:
+                result['classification']['labels_sugeridos'].append(subtipo)
 
-        logger.info(f'[Resultado] Classificação: tipo={tipo}, labels={result["classification"].get("labels_sugeridos", [])}')
+        logger.info(f'[Resultado] Classificação: tipo={tipo}, subtipo={subtipo}, labels={result["classification"].get("labels_sugeridos", [])}')
 
         if result['classification'].get('interessado'):
             click.echo('\nGerando resposta ao usuário...')

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -88,6 +88,7 @@ def init(base_dir: str, force: bool, stats: bool):
 @click.option('--llm-model', type=str, default=None, help='Modelo do LLM (default: config.yaml ou qwen2.5:7b).')
 @click.option('--gitlab-token', type=str, envvar='GITLAB_TOKEN', default=None, help='Token GitLab.')
 @click.option('--mode', type=click.Choice(['auto', 'single', 'multi', 'loop']), default='auto', help='Modo: auto, single (1 prompt), multi (3 prompts fixos), loop (iterativo, LLM decide).')
+@click.option('--env-file', type=click.Path(), default=None, help='Caminho para .env (default: .iac/.env).')
 @click.option('--dry-run', is_flag=True, help='Não posta comentários nem aplica labels.')
 @click.option('--post', is_flag=True, help='Postar análise como comentário na issue.')
 def analyze(
@@ -101,6 +102,7 @@ def analyze(
     llm_model: str,
     gitlab_token: str,
     mode: str,
+    env_file: str,
     dry_run: bool,
     post: bool,
 ):
@@ -108,6 +110,16 @@ def analyze(
     if not issue_url and not title and not description:
         click.echo('Informe --issue-url, --title ou --description.')
         sys.exit(1)
+
+    # Carregar .env se informado via --env-file
+    if env_file:
+        from dotenv import load_dotenv
+        env_path = Path(env_file)
+        if env_path.exists():
+            load_dotenv(env_path, override=False)
+        else:
+            click.echo(f'Arquivo .env não encontrado: {env_file}')
+            sys.exit(1)
 
     base = Path(base_dir).resolve()
     iac_dir = base / IAC_DIR

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -12,6 +12,7 @@ Uso:
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -144,8 +145,8 @@ def analyze(
     if llm and not llm_model:
         llm_model = cfg['llm']['model']
     llm_url = llm_url or cfg['llm'].get('url')
-    llm_key = llm_key or cfg['llm'].get('key')
-    gitlab_token = gitlab_token or cfg['gitlab'].get('token')
+    llm_key = llm_key or cfg['llm'].get('key') or os.environ.get('GROQ_API_KEY') or os.environ.get('GEMINI_API_KEY')
+    gitlab_token = gitlab_token or cfg['gitlab'].get('token') or os.environ.get('GITLAB_TOKEN')
     mode = cfg['analyze'].get('mode', mode)
 
     structure = load_structure(iac_dir)
@@ -187,6 +188,16 @@ def analyze(
         description = ''
 
     # Log dos argumentos de entrada
+    # Validar API key para backends que exigem
+    if llm in ('groq', 'gemini') and not llm_key:
+        env_var = 'GROQ_API_KEY' if llm == 'groq' else 'GEMINI_API_KEY'
+        click.echo(f'API key necessária para {llm}. Use --llm-key, {env_var} ou config.yaml.')
+        sys.exit(1)
+
+    # URL default por backend (se não informado)
+    if llm == 'groq' and (not llm_url or 'localhost' in llm_url):
+        llm_url = 'https://api.groq.com/openai/v1/chat/completions'
+
     logger.info('=== iac analyze iniciado ===')
     logger.info(f'Base dir: {base}')
     logger.info(f'Issue URL: {issue_url or "(não informado)"}')

--- a/src/iac/config/app_settings.py
+++ b/src/iac/config/app_settings.py
@@ -4,21 +4,42 @@ Princípio 1 — Explícito sobre Implícito:
 todas as configurações tipadas, com defaults explícitos e validação.
 
 Hierarquia: defaults → config.yaml → variáveis de ambiente → CLI args.
+
+Variáveis de ambiente aceitas:
+    GROQ_API_KEY     — API key do Groq (gratuito)
+    GITLAB_TOKEN     — Access token do GitLab
+    GEMINI_API_KEY   — API key do Google Gemini
+    IAC_LLM_BACKEND  — Backend LLM (ollama, groq, gemini)
+    IAC_LLM_MODEL    — Nome do modelo
+    IAC_LLM_URL      — Endpoint da API
+    IAC_LLM_KEY      — API key genérica (fallback)
 """
 
 from __future__ import annotations
+
+import os
 
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
+def _resolve_llm_key() -> str | None:
+    """Resolve API key pela ordem: GROQ_API_KEY → GEMINI_API_KEY → IAC_LLM_KEY."""
+    return os.environ.get('GROQ_API_KEY') or os.environ.get('GEMINI_API_KEY') or os.environ.get('IAC_LLM_KEY')
+
+
+def _resolve_gitlab_token() -> str | None:
+    """Resolve token pela ordem: GITLAB_TOKEN → IAC_GITLAB_TOKEN."""
+    return os.environ.get('GITLAB_TOKEN') or os.environ.get('IAC_GITLAB_TOKEN')
+
+
 class LLMSettings(BaseSettings):
     """Configurações do backend LLM."""
 
-    backend: str = Field('ollama', description='Backend: ollama | gemini')
+    backend: str = Field('ollama', description='Backend: ollama | groq | gemini')
     model: str = Field('qwen2.5:7b', description='Nome do modelo')
     url: str = Field('http://localhost:11434/v1/chat/completions', description='Endpoint da API')
-    key: str | None = Field(None, description='API key (opcional para Ollama local)')
+    key: str | None = Field(default_factory=_resolve_llm_key, description='API key (GROQ_API_KEY, GEMINI_API_KEY ou IAC_LLM_KEY)')
     max_tokens: int = Field(4000, description='Máximo de tokens na resposta')
     temperature: float = Field(0.2, description='Temperatura do modelo')
     timeout: int = Field(1200, description='Timeout em segundos')
@@ -30,7 +51,7 @@ class GitLabSettings(BaseSettings):
     """Configurações do GitLab."""
 
     url: str | None = Field(None, description='URL do GitLab')
-    token: str | None = Field(None, description='Access token')
+    token: str | None = Field(default_factory=_resolve_gitlab_token, description='Access token (GITLAB_TOKEN ou IAC_GITLAB_TOKEN)')
     project_id: str | None = Field(None, description='ID do projeto')
 
     model_config = {'env_prefix': 'IAC_GITLAB_'}
@@ -39,7 +60,7 @@ class GitLabSettings(BaseSettings):
 class AnalyzeSettings(BaseSettings):
     """Configurações do comando analyze."""
 
-    mode: str = Field('auto', description='Modo: auto | single | multi')
+    mode: str = Field('auto', description='Modo: auto | single | multi | loop')
 
     model_config = {'env_prefix': 'IAC_ANALYZE_'}
 

--- a/src/iac/config/app_settings.py
+++ b/src/iac/config/app_settings.py
@@ -21,7 +21,7 @@ class LLMSettings(BaseSettings):
     key: str | None = Field(None, description='API key (opcional para Ollama local)')
     max_tokens: int = Field(4000, description='Máximo de tokens na resposta')
     temperature: float = Field(0.2, description='Temperatura do modelo')
-    timeout: int = Field(600, description='Timeout em segundos')
+    timeout: int = Field(1200, description='Timeout em segundos')
 
     model_config = {'env_prefix': 'IAC_LLM_'}
 

--- a/src/iac/config/app_settings.py
+++ b/src/iac/config/app_settings.py
@@ -24,8 +24,8 @@ from pydantic_settings import BaseSettings
 
 
 def _resolve_llm_key() -> str | None:
-    """Resolve API key pela ordem: GROQ_API_KEY → GEMINI_API_KEY → IAC_LLM_KEY."""
-    return os.environ.get('GROQ_API_KEY') or os.environ.get('GEMINI_API_KEY') or os.environ.get('IAC_LLM_KEY')
+    """Resolve API key pela ordem: GROQ_API_KEY → DEEPSEEK_API_KEY → GEMINI_API_KEY → IAC_LLM_KEY."""
+    return os.environ.get('GROQ_API_KEY') or os.environ.get('DEEPSEEK_API_KEY') or os.environ.get('GEMINI_API_KEY') or os.environ.get('IAC_LLM_KEY')
 
 
 def _resolve_gitlab_token() -> str | None:

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -123,8 +123,31 @@ def save_graph(iac_dir: Path, graph: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _load_dotenv(iac_dir: Path, user_config: dict) -> None:
+    """Carrega .env se configurado ou se existir no .iac/.
+
+    Prioridade: config.yaml (env_file) → .iac/.env → argumento --env-file.
+    """
+    from dotenv import load_dotenv
+
+    env_path = user_config.get('env_file')
+    if env_path:
+        env_file = Path(env_path)
+        if not env_file.is_absolute():
+            env_file = iac_dir / env_file
+    else:
+        env_file = iac_dir / '.env'
+
+    if env_file.exists():
+        load_dotenv(env_file, override=False)
+        logger.info(f'Variáveis carregadas de {env_file}')
+
+
 def load_user_config(iac_dir: Path) -> dict:
     """Carrega config.yaml do .iac/. Retorna defaults se não existir.
+
+    Também carrega .env se existir em .iac/.env ou no caminho
+    configurado em config.yaml (env_file: caminho/para/.env).
 
     Args:
         iac_dir: Caminho para o diretório .iac do projeto.
@@ -134,10 +157,13 @@ def load_user_config(iac_dir: Path) -> dict:
     """
     config_file = iac_dir / CONFIG_FILE
     if not config_file.exists():
+        _load_dotenv(iac_dir, {})
         return dict(DEFAULT_CONFIG)
 
     with open(config_file, encoding='utf-8') as f:
         user_config = yaml.safe_load(f) or {}
+
+    _load_dotenv(iac_dir, user_config)
 
     # Merge com defaults (user sobrescreve)
     merged = dict(DEFAULT_CONFIG)

--- a/src/iac/integrations/deepseek.py
+++ b/src/iac/integrations/deepseek.py
@@ -76,9 +76,13 @@ def chat(
             logger.error(f'Requisição ao DeepSeek falhou: {e}')
             return None
 
-        if response.status_code in (429, 413):
+        if response.status_code == 413:
+            logger.warning(f'[DeepSeek] Prompt muito grande (413) — {len(prompt)} chars excede limite do modelo')
+            return 'PROMPT_TOO_LARGE'
+
+        if response.status_code == 429:
             wait = _parse_retry_after(response.text)
-            logger.warning(f'[DeepSeek] Rate limit ({response.status_code}) — aguardando {wait}s (tentativa {attempt}/{DEFAULT_MAX_RETRIES})')
+            logger.warning(f'[DeepSeek] Rate limit (429) — aguardando {wait}s (tentativa {attempt}/{DEFAULT_MAX_RETRIES})')
             time.sleep(wait)
             continue
 

--- a/src/iac/integrations/deepseek.py
+++ b/src/iac/integrations/deepseek.py
@@ -1,0 +1,105 @@
+"""Backend LLM: DeepSeek — modelos especializados em código (API compatível OpenAI).
+
+Modelos disponíveis:
+    deepseek-coder — especialista em código, melhor custo
+    deepseek-chat (V3) — generalista forte, raciocínio próximo ao GPT-4
+    deepseek-reasoner (R1) — chain-of-thought, raciocínio profundo
+
+$5 de crédito grátis ao criar conta (sem cartão).
+API key: https://platform.deepseek.com/api_keys
+
+Variáveis de ambiente:
+    DEEPSEEK_API_KEY — API key (obrigatória)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_URL = 'https://api.deepseek.com/v1/chat/completions'
+DEFAULT_TIMEOUT = 120
+DEFAULT_MAX_TOKENS = 4000
+DEFAULT_TEMPERATURE = 0.2
+DEFAULT_MAX_RETRIES = int(os.environ.get('IAC_LLM_MAX_RETRIES', '3'))
+
+
+def chat(
+    prompt: str,
+    url: str = DEFAULT_URL,
+    model: str = 'deepseek-coder',
+    api_key: str | None = None,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    temperature: float = DEFAULT_TEMPERATURE,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> str | None:
+    """Envia prompt ao DeepSeek com retry automático em rate limit.
+
+    Args:
+        prompt: Texto do prompt.
+        url: Endpoint da API.
+        model: Nome do modelo (deepseek-coder, deepseek-chat, deepseek-reasoner).
+        api_key: Chave da API (obrigatória).
+        max_tokens: Máximo de tokens na resposta.
+        temperature: Temperatura do modelo.
+        timeout: Timeout em segundos.
+
+    Returns:
+        Texto da resposta ou None em caso de erro.
+    """
+    if not api_key:
+        logger.error('DeepSeek requer api_key. Defina DEEPSEEK_API_KEY ou use --llm-key.')
+        return None
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {api_key}',
+    }
+
+    data = {
+        'model': model,
+        'messages': [{'role': 'user', 'content': prompt}],
+        'max_tokens': max_tokens,
+        'temperature': temperature,
+    }
+
+    for attempt in range(1, DEFAULT_MAX_RETRIES + 1):
+        try:
+            response = requests.post(url, headers=headers, json=data, timeout=timeout)
+        except requests.RequestException as e:
+            logger.error(f'Requisição ao DeepSeek falhou: {e}')
+            return None
+
+        if response.status_code in (429, 413):
+            wait = _parse_retry_after(response.text)
+            logger.warning(f'[DeepSeek] Rate limit ({response.status_code}) — aguardando {wait}s (tentativa {attempt}/{DEFAULT_MAX_RETRIES})')
+            time.sleep(wait)
+            continue
+
+        if response.status_code != 200:
+            logger.error(f'DeepSeek API erro: {response.status_code} - {response.text}')
+            return None
+
+        try:
+            result = response.json()
+            return result['choices'][0]['message']['content']
+        except Exception as e:
+            logger.error(f'Erro ao parsear resposta DeepSeek: {e}')
+            return None
+
+    logger.error(f'[DeepSeek] Rate limit excedido após {DEFAULT_MAX_RETRIES} tentativas')
+    return None
+
+
+def _parse_retry_after(error_text: str) -> float:
+    """Extrai tempo de espera da mensagem de erro do DeepSeek."""
+    match = re.search(r'try again in (\d+\.?\d*)s', error_text, re.IGNORECASE)
+    if match:
+        return float(match.group(1)) + 1.0
+    return 30.0

--- a/src/iac/integrations/groq.py
+++ b/src/iac/integrations/groq.py
@@ -28,8 +28,7 @@ DEFAULT_URL = 'https://api.groq.com/openai/v1/chat/completions'
 DEFAULT_TIMEOUT = 60
 DEFAULT_MAX_TOKENS = 4000
 DEFAULT_TEMPERATURE = 0.2
-DEFAULT_RATE_DELAY = int(os.environ.get('GROQ_RATE_DELAY', '0'))
-DEFAULT_MAX_RETRIES = int(os.environ.get('GROQ_MAX_RETRIES', '3'))
+DEFAULT_MAX_RETRIES = int(os.environ.get('IAC_LLM_MAX_RETRIES', '3'))
 
 
 def chat(
@@ -70,10 +69,6 @@ def chat(
         'max_tokens': max_tokens,
         'temperature': temperature,
     }
-
-    if DEFAULT_RATE_DELAY > 0:
-        logger.debug(f'[Groq] Rate delay: {DEFAULT_RATE_DELAY}s')
-        time.sleep(DEFAULT_RATE_DELAY)
 
     for attempt in range(1, DEFAULT_MAX_RETRIES + 1):
         try:

--- a/src/iac/integrations/groq.py
+++ b/src/iac/integrations/groq.py
@@ -82,9 +82,9 @@ def chat(
             logger.error(f'Requisição ao Groq falhou: {e}')
             return None
 
-        if response.status_code == 429:
+        if response.status_code in (429, 413):
             wait = _parse_retry_after(response.text)
-            logger.warning(f'[Groq] Rate limit (429) — aguardando {wait}s (tentativa {attempt}/{DEFAULT_MAX_RETRIES})')
+            logger.warning(f'[Groq] Rate limit ({response.status_code}) — aguardando {wait}s (tentativa {attempt}/{DEFAULT_MAX_RETRIES})')
             time.sleep(wait)
             continue
 
@@ -104,8 +104,11 @@ def chat(
 
 
 def _parse_retry_after(error_text: str) -> float:
-    """Extrai tempo de espera da mensagem de erro 429 do Groq."""
+    """Extrai tempo de espera da mensagem de erro 429/413 do Groq."""
     match = re.search(r'try again in (\d+\.?\d*)s', error_text, re.IGNORECASE)
     if match:
         return float(match.group(1)) + 1.0
+    # 413 (request too large) — tokens/min reseta em ~60s
+    if 'Request too large' in error_text or '413' in error_text:
+        return 60.0
     return 30.0

--- a/src/iac/integrations/groq.py
+++ b/src/iac/integrations/groq.py
@@ -77,9 +77,13 @@ def chat(
             logger.error(f'Requisição ao Groq falhou: {e}')
             return None
 
-        if response.status_code in (429, 413):
+        if response.status_code == 413:
+            logger.warning(f'[Groq] Prompt muito grande (413) — {len(prompt)} chars excede limite do modelo')
+            return 'PROMPT_TOO_LARGE'
+
+        if response.status_code == 429:
             wait = _parse_retry_after(response.text)
-            logger.warning(f'[Groq] Rate limit ({response.status_code}) — aguardando {wait}s (tentativa {attempt}/{DEFAULT_MAX_RETRIES})')
+            logger.warning(f'[Groq] Rate limit (429) — aguardando {wait}s (tentativa {attempt}/{DEFAULT_MAX_RETRIES})')
             time.sleep(wait)
             continue
 

--- a/src/iac/integrations/groq.py
+++ b/src/iac/integrations/groq.py
@@ -1,0 +1,76 @@
+"""Backend LLM: Groq — inferência rápida via API (compatível OpenAI).
+
+Modelos disponíveis (gratuito com rate limit):
+    llama-3.1-8b-instant, llama-3.1-70b-versatile,
+    llama-3.3-70b-versatile, mixtral-8x7b-32768, gemma2-9b-it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_URL = 'https://api.groq.com/openai/v1/chat/completions'
+DEFAULT_TIMEOUT = 60  # Groq é rápido (~1-3s)
+DEFAULT_MAX_TOKENS = 4000
+DEFAULT_TEMPERATURE = 0.2
+
+
+def chat(
+    prompt: str,
+    url: str = DEFAULT_URL,
+    model: str = 'llama-3.1-70b-versatile',
+    api_key: str | None = None,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    temperature: float = DEFAULT_TEMPERATURE,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> str | None:
+    """Envia prompt ao Groq e retorna a resposta.
+
+    Args:
+        prompt: Texto do prompt.
+        url: Endpoint da API.
+        model: Nome do modelo Groq.
+        api_key: Chave da API (obrigatória).
+        max_tokens: Máximo de tokens na resposta.
+        temperature: Temperatura do modelo.
+        timeout: Timeout em segundos.
+
+    Returns:
+        Texto da resposta ou None em caso de erro.
+    """
+    if not api_key:
+        logger.error('Groq requer api_key. Obtenha em https://console.groq.com/keys')
+        return None
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {api_key}',
+    }
+
+    data = {
+        'model': model,
+        'messages': [{'role': 'user', 'content': prompt}],
+        'max_tokens': max_tokens,
+        'temperature': temperature,
+    }
+
+    try:
+        response = requests.post(url, headers=headers, json=data, timeout=timeout)
+    except requests.RequestException as e:
+        logger.error(f'Requisição ao Groq falhou: {e}')
+        return None
+
+    if response.status_code != 200:
+        logger.error(f'Groq API erro: {response.status_code} - {response.text}')
+        return None
+
+    try:
+        result = response.json()
+        return result['choices'][0]['message']['content']
+    except Exception as e:
+        logger.error(f'Erro ao parsear resposta Groq: {e}')
+        return None

--- a/src/iac/integrations/groq.py
+++ b/src/iac/integrations/groq.py
@@ -1,34 +1,47 @@
 """Backend LLM: Groq — inferência rápida via API (compatível OpenAI).
 
 Modelos disponíveis (gratuito com rate limit):
-    llama-3.1-8b-instant, llama-3.1-70b-versatile,
-    llama-3.3-70b-versatile, mixtral-8x7b-32768, gemma2-9b-it.
+    llama-3.1-8b-instant, llama-3.3-70b-versatile,
+    qwen/qwen3-32b, meta-llama/llama-4-scout-17b-16e-instruct.
+
+Rate limit (tier gratuito): ~6.000-12.000 tokens/min.
+Retry automático com backoff quando 429 é retornado.
+
+Variáveis de ambiente:
+    GROQ_API_KEY       — API key (obrigatória)
+    GROQ_RATE_DELAY    — Delay em segundos entre chamadas (default: 0)
+    GROQ_MAX_RETRIES   — Máximo de retries em rate limit (default: 3)
 """
 
 from __future__ import annotations
 
 import logging
+import os
+import re
+import time
 
 import requests
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_URL = 'https://api.groq.com/openai/v1/chat/completions'
-DEFAULT_TIMEOUT = 60  # Groq é rápido (~1-3s)
+DEFAULT_TIMEOUT = 60
 DEFAULT_MAX_TOKENS = 4000
 DEFAULT_TEMPERATURE = 0.2
+DEFAULT_RATE_DELAY = int(os.environ.get('GROQ_RATE_DELAY', '0'))
+DEFAULT_MAX_RETRIES = int(os.environ.get('GROQ_MAX_RETRIES', '3'))
 
 
 def chat(
     prompt: str,
     url: str = DEFAULT_URL,
-    model: str = 'llama-3.1-70b-versatile',
+    model: str = 'llama-3.3-70b-versatile',
     api_key: str | None = None,
     max_tokens: int = DEFAULT_MAX_TOKENS,
     temperature: float = DEFAULT_TEMPERATURE,
     timeout: int = DEFAULT_TIMEOUT,
 ) -> str | None:
-    """Envia prompt ao Groq e retorna a resposta.
+    """Envia prompt ao Groq com retry automático em rate limit.
 
     Args:
         prompt: Texto do prompt.
@@ -43,7 +56,7 @@ def chat(
         Texto da resposta ou None em caso de erro.
     """
     if not api_key:
-        logger.error('Groq requer api_key. Obtenha em https://console.groq.com/keys')
+        logger.error('Groq requer api_key. Defina GROQ_API_KEY ou use --llm-key.')
         return None
 
     headers = {
@@ -58,19 +71,41 @@ def chat(
         'temperature': temperature,
     }
 
-    try:
-        response = requests.post(url, headers=headers, json=data, timeout=timeout)
-    except requests.RequestException as e:
-        logger.error(f'Requisição ao Groq falhou: {e}')
-        return None
+    if DEFAULT_RATE_DELAY > 0:
+        logger.debug(f'[Groq] Rate delay: {DEFAULT_RATE_DELAY}s')
+        time.sleep(DEFAULT_RATE_DELAY)
 
-    if response.status_code != 200:
-        logger.error(f'Groq API erro: {response.status_code} - {response.text}')
-        return None
+    for attempt in range(1, DEFAULT_MAX_RETRIES + 1):
+        try:
+            response = requests.post(url, headers=headers, json=data, timeout=timeout)
+        except requests.RequestException as e:
+            logger.error(f'Requisição ao Groq falhou: {e}')
+            return None
 
-    try:
-        result = response.json()
-        return result['choices'][0]['message']['content']
-    except Exception as e:
-        logger.error(f'Erro ao parsear resposta Groq: {e}')
-        return None
+        if response.status_code == 429:
+            wait = _parse_retry_after(response.text)
+            logger.warning(f'[Groq] Rate limit (429) — aguardando {wait}s (tentativa {attempt}/{DEFAULT_MAX_RETRIES})')
+            time.sleep(wait)
+            continue
+
+        if response.status_code != 200:
+            logger.error(f'Groq API erro: {response.status_code} - {response.text}')
+            return None
+
+        try:
+            result = response.json()
+            return result['choices'][0]['message']['content']
+        except Exception as e:
+            logger.error(f'Erro ao parsear resposta Groq: {e}')
+            return None
+
+    logger.error(f'[Groq] Rate limit excedido após {DEFAULT_MAX_RETRIES} tentativas')
+    return None
+
+
+def _parse_retry_after(error_text: str) -> float:
+    """Extrai tempo de espera da mensagem de erro 429 do Groq."""
+    match = re.search(r'try again in (\d+\.?\d*)s', error_text, re.IGNORECASE)
+    if match:
+        return float(match.group(1)) + 1.0
+    return 30.0

--- a/src/iac/integrations/ollama.py
+++ b/src/iac/integrations/ollama.py
@@ -11,7 +11,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT = 600  # 10 min — modelos em CPU podem ser lentos
+DEFAULT_TIMEOUT = 1200  # 20 min — modelos 14B em CPU podem ser muito lentos
 DEFAULT_MAX_TOKENS = 4000
 DEFAULT_TEMPERATURE = 0.2
 

--- a/tests/test_agent/test_integrations.py
+++ b/tests/test_agent/test_integrations.py
@@ -1,0 +1,218 @@
+"""Testes para integrações LLM — rate limit, fallback, ajuste progressivo.
+
+Cobre: 413 (prompt too large), 429 (rate limit), PROMPT_TOO_LARGE no runner,
+ajuste progressivo no run_single, retry no groq/deepseek.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from iac.agent.runner import send_to_llm
+
+
+# ---------------------------------------------------------------------------
+# groq.py — 413 retorna PROMPT_TOO_LARGE sem retry
+# ---------------------------------------------------------------------------
+
+
+def test_groq_413_returns_prompt_too_large():
+    """Groq 413 deve retornar 'PROMPT_TOO_LARGE' imediatamente, sem retry."""
+    mock_response = MagicMock()
+    mock_response.status_code = 413
+    mock_response.text = 'Request too large for model'
+
+    with patch('iac.integrations.groq.requests.post', return_value=mock_response):
+        from iac.integrations.groq import chat
+        result = chat('prompt grande', api_key='test-key')
+        assert result == 'PROMPT_TOO_LARGE'
+
+
+def test_groq_429_retries():
+    """Groq 429 deve fazer retry com backoff."""
+    mock_429 = MagicMock()
+    mock_429.status_code = 429
+    mock_429.text = 'Please try again in 1.0s'
+
+    mock_200 = MagicMock()
+    mock_200.status_code = 200
+    mock_200.json.return_value = {'choices': [{'message': {'content': 'resposta ok'}}]}
+
+    with patch('iac.integrations.groq.requests.post', side_effect=[mock_429, mock_200]):
+        with patch('iac.integrations.groq.time.sleep'):
+            from iac.integrations.groq import chat
+            result = chat('prompt', api_key='test-key')
+            assert result == 'resposta ok'
+
+
+def test_groq_429_max_retries_exhausted():
+    """Groq 429 × max_retries deve retornar None."""
+    mock_429 = MagicMock()
+    mock_429.status_code = 429
+    mock_429.text = 'Please try again in 1.0s'
+
+    with patch('iac.integrations.groq.requests.post', return_value=mock_429):
+        with patch('iac.integrations.groq.time.sleep'):
+            with patch('iac.integrations.groq.DEFAULT_MAX_RETRIES', 2):
+                from iac.integrations.groq import chat
+                result = chat('prompt', api_key='test-key')
+                assert result is None
+
+
+def test_groq_sem_api_key():
+    """Groq sem api_key deve retornar None com erro."""
+    from iac.integrations.groq import chat
+    result = chat('prompt', api_key=None)
+    assert result is None
+
+
+def test_groq_200_ok():
+    """Groq 200 deve retornar conteúdo."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'choices': [{'message': {'content': 'análise completa'}}]}
+
+    with patch('iac.integrations.groq.requests.post', return_value=mock_response):
+        from iac.integrations.groq import chat
+        result = chat('prompt', api_key='test-key')
+        assert result == 'análise completa'
+
+
+def test_groq_500_returns_none():
+    """Groq 500 (erro servidor) deve retornar None."""
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = 'Internal Server Error'
+
+    with patch('iac.integrations.groq.requests.post', return_value=mock_response):
+        from iac.integrations.groq import chat
+        result = chat('prompt', api_key='test-key')
+        assert result is None
+
+
+def test_groq_connection_error():
+    """Groq connection error deve retornar None."""
+    import requests
+
+    with patch('iac.integrations.groq.requests.post', side_effect=requests.ConnectionError('offline')):
+        from iac.integrations.groq import chat
+        result = chat('prompt', api_key='test-key')
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# deepseek.py — mesmos padrões
+# ---------------------------------------------------------------------------
+
+
+def test_deepseek_413_returns_prompt_too_large():
+    """DeepSeek 413 deve retornar 'PROMPT_TOO_LARGE'."""
+    mock_response = MagicMock()
+    mock_response.status_code = 413
+    mock_response.text = 'Request too large'
+
+    with patch('iac.integrations.deepseek.requests.post', return_value=mock_response):
+        from iac.integrations.deepseek import chat
+        result = chat('prompt', api_key='test-key')
+        assert result == 'PROMPT_TOO_LARGE'
+
+
+def test_deepseek_sem_api_key():
+    """DeepSeek sem api_key deve retornar None."""
+    from iac.integrations.deepseek import chat
+    result = chat('prompt', api_key=None)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# send_to_llm — propaga PROMPT_TOO_LARGE
+# ---------------------------------------------------------------------------
+
+
+def test_send_to_llm_propaga_prompt_too_large():
+    """send_to_llm deve propagar PROMPT_TOO_LARGE do backend."""
+    with patch('iac.integrations.groq.chat', return_value='PROMPT_TOO_LARGE'):
+        result = send_to_llm('prompt', 'groq', 'model', None, 'key')
+        assert result == 'PROMPT_TOO_LARGE'
+
+
+def test_send_to_llm_groq_sucesso():
+    """send_to_llm com groq deve retornar resposta."""
+    with patch('iac.integrations.groq.chat', return_value='análise ok'):
+        result = send_to_llm('prompt', 'groq', 'model', None, 'key')
+        assert result == 'análise ok'
+
+
+def test_send_to_llm_ollama_sem_rate_delay():
+    """send_to_llm com ollama não deve aplicar rate delay."""
+    with patch('iac.integrations.ollama.chat', return_value='resp') as mock_chat:
+        with patch('iac.agent.runner.time.sleep') as mock_sleep:
+            result = send_to_llm('prompt', 'ollama', 'model', 'http://localhost:11434/v1/chat/completions', None)
+            # Ollama não deve ter delay
+            mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_single — ajuste progressivo
+# ---------------------------------------------------------------------------
+
+
+def test_run_single_fallback_sem_deep():
+    """run_single deve retentar sem deep quando 413."""
+    result = {
+        'structural': {'components': [], 'flow': [], 'issue_data': {}},
+        'context': {'view': None, 'references': [], 'steps': 0, 'context_chars': 0},
+        'deep': [{'fqn': 'app.Model', 'fields': [], 'constants': {}, 'depth': 0, 'file': 'models.py', 'line': 1}],
+    }
+
+    call_count = {'n': 0}
+
+    def mock_send(prompt, llm, model, url, key):
+        call_count['n'] += 1
+        if call_count['n'] == 1:
+            return 'PROMPT_TOO_LARGE'
+        return 'CLASSIFICAÇÃO: tipo::bug\nAnálise sem deep.'
+
+    with patch('iac.agent.runner.send_to_llm', side_effect=mock_send):
+        from iac.agent.runner import run_single
+        analysis = run_single(result, 'groq', 'llama-3.3-70b-versatile', None, 'key')
+        assert analysis is not None
+        assert 'tipo::bug' in analysis
+        assert call_count['n'] == 2  # Tentou 2x: com deep, sem deep
+
+
+def test_run_single_413_duas_vezes_retorna_none():
+    """run_single deve retornar None se 413 persiste mesmo sem deep."""
+    result = {
+        'structural': {'components': [], 'flow': [], 'issue_data': {}},
+        'context': {'view': None, 'references': [], 'steps': 0, 'context_chars': 0},
+        'deep': [],
+    }
+
+    with patch('iac.agent.runner.send_to_llm', return_value='PROMPT_TOO_LARGE'):
+        from iac.agent.runner import run_single
+        analysis = run_single(result, 'groq', 'llama-3.1-8b-instant', None, 'key')
+        assert analysis is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_retry_after
+# ---------------------------------------------------------------------------
+
+
+def test_parse_retry_after_groq():
+    """Parse do tempo de espera da mensagem 429 do Groq."""
+    from iac.integrations.groq import _parse_retry_after
+    assert _parse_retry_after('Please try again in 25.08s') == pytest.approx(26.08, abs=0.1)
+
+
+def test_parse_retry_after_sem_match():
+    """Sem tempo na mensagem, retorna default."""
+    from iac.integrations.groq import _parse_retry_after
+    assert _parse_retry_after('Rate limit exceeded') == 30.0
+
+
+def test_parse_retry_after_413():
+    """413 sem retry time, retorna 60s."""
+    from iac.integrations.groq import _parse_retry_after
+    assert _parse_retry_after('Request too large for model') == 60.0

--- a/tests/test_agent/test_loop.py
+++ b/tests/test_agent/test_loop.py
@@ -5,7 +5,7 @@ _request_key, detecção de repetição.
 """
 
 from iac.agent.loop import _detect_action, _request_key
-from iac.agent.prompts.utils import _normalize_label, extract_tipo_from_analysis
+from iac.agent.prompts.utils import _normalize_label, extract_tipo_from_analysis, normalize_to_known
 
 
 # ---------------------------------------------------------------------------
@@ -113,3 +113,56 @@ def test_request_key_model():
 def test_request_key_symbol():
     key = _request_key({'type': 'symbol', 'name': 'SomeSymbol'})
     assert key == 'SomeSymbol'
+
+
+# ---------------------------------------------------------------------------
+# _detect_action — variantes de CLASSIFICAR (#52)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_classificar_markdown():
+    """CLASSIFICAR com bold markdown — deve reconhecer."""
+    assert _detect_action('**AÇÃO: CLASSIFICAR**\n**CLASSIFICAÇÃO:** tipo::bug') == 'CLASSIFICAR'
+
+
+def test_detect_classificar_solo():
+    """CLASSIFICAR sozinho em linha — deve reconhecer."""
+    assert _detect_action('Análise completa.\n\nCLASSIFICAR\n\nO problema é...') == 'CLASSIFICAR'
+
+
+def test_detect_classificar_sections():
+    """Seções ### Análise + ### Resolução sem AÇÃO: — deve inferir CLASSIFICAR."""
+    response = '### Análise\nCausa raiz...\n### Resolução\nCorrigir...'
+    assert _detect_action(response) == 'CLASSIFICAR'
+
+
+def test_detect_classificacao_without_accents():
+    """CLASSIFICACAO sem acento — deve reconhecer."""
+    assert _detect_action('CLASSIFICACAO: tipo::prazo-expirado') == 'CLASSIFICAR'
+
+
+# ---------------------------------------------------------------------------
+# normalize_to_known — taxonomia (#52)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_avaliacao_nao_disponivel():
+    assert normalize_to_known('tipo::avaliacao-nao-disponivel') == 'tipo::prazo-expirado'
+
+
+def test_normalize_logica_incorreta():
+    assert normalize_to_known('tipo::logica-incorreta') == 'tipo::bug'
+
+
+def test_normalize_acesso_negado():
+    assert normalize_to_known('tipo::acesso-negado') == 'tipo::permissao'
+
+
+def test_normalize_unknown_returns_none():
+    assert normalize_to_known('tipo::algo-desconhecido') is None
+
+
+def test_normalize_known_tipo_not_aliased():
+    """Labels já conhecidos não precisam de alias."""
+    assert normalize_to_known('tipo::bug') is None
+    assert normalize_to_known('tipo::prazo-expirado') is None

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -124,7 +124,7 @@ def test_response_prompt_has_orientations():
     analysis = 'CLASSIFICAÇÃO: tipo::configuracao\nOrientação ao responsável.'
     prompt = build_response_prompt(result, analysis)
     assert 'João Silva' in prompt
-    assert 'Prezado(a)' in prompt
+    assert 'desenvolvedor' in prompt
     assert 'tipo::configuracao' in prompt
     assert 'Orientação ao responsável' in prompt
 
@@ -135,7 +135,7 @@ def test_response_prompt_has_analysis():
     prompt = build_response_prompt(result, analysis)
     assert 'João Silva' in prompt
     assert 'Erro no código' in prompt
-    assert 'NUNCA culpe' in prompt
+    assert 'Diagnóstico' in prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Resumo

- Guardrails do loop: detect_action tolerante, repair prompt, min_iterations=2, taxonomia normalizada
- Integrações Groq e DeepSeek (APIs gratuitas, ~1-3s por prompt)
- Configuração via .env (zero argumentos obrigatórios)
- Ajuste progressivo do prompt (413 → sem deep)
- Prompt de resposta direcionado ao desenvolvedor
- Subclassificação exibida no resultado
- 17 testes de integração (413, 429, fallback)
- Bateria de 12 cenários Groq (4 modelos × 3 modos)
- docs/ARCHITECTURE.md atualizado

## Detalhes

### Loop guardrails (#52)
- `_detect_action()` reconhece CLASSIFICAR com markdown, sozinho, por seções
- `min_iterations=2` impede classificação prematura
- `normalize_to_known()` mapeia labels fora do catálogo
- Repair prompt para respostas sem classificação
- Enriquecimento limitado a 4 métodos focais

### Integrações (#57, #58)
- `integrations/groq.py` — retry 429, PROMPT_TOO_LARGE no 413
- `integrations/deepseek.py` — mesma estrutura
- `runner.py` — rate delay genérico (IAC_LLM_RATE_DELAY)
- `cli.py` — aceita `--llm groq|deepseek`, URL default por backend

### Configuração
- `.iac/.env` carregado automaticamente
- `IAC_LLM_BACKEND`, `IAC_LLM_MODEL`, `GROQ_API_KEY`, `GITLAB_TOKEN` via env
- `.env.example` com todas as variáveis documentadas

### Multi/Single (#53, #54)
- Parse rejeita expressões complexas e query fragments
- Single omite deep para modelos small (7B)
- Ajuste progressivo: 413 → retenta sem deep

## Resultados da bateria Groq

| Modelo | single | multi | loop |
|--------|--------|-------|------|
| llama-3.1-8b | ❌ bug | ✅ nao-e-erro | ⚠️ parcial |
| llama-4-scout-17b | ✅✅ nao-e-erro/prazo-expirado | ❌ bug | ⚠️ parcial |
| qwen3-32b | ❌ 413 | ❌ bug | ❌ None |
| llama-3.3-70b | ❌ 413 | ✅ nao-e-erro | ⚠️ parcial |

## Test plan

- [x] `ruff check src/` → zero erros
- [x] `pylint --max-module-lines=400` → ok
- [x] `pytest tests/` → 153 passed
- [x] 12 cenários Groq executados com logs em `.iac/logs/groq/`

Closes #52, #53, #54, #57