### PR TITLE
refactor: core genérico — profile.yaml, taxonomia configurável, classifier sem viés, init completo

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,11 +8,11 @@ Este projeto segue os 6 princípios da [Arquitetura AI-Native](https://lemon.dev
 
 | Princípio | Aplicação no IAC | Score |
 |-----------|-----------------|-------|
-| **1. Explícito sobre Implícito** | `AppSettings` (Pydantic Settings), `.env` com todas as variáveis, `KNOWN_TIPOS` + `_LABEL_ALIASES` codificam taxonomia, `MODEL_PROFILES` explícitos | ✅ |
+| **1. Explícito sobre Implícito** | `profile.yaml` configurável por projeto (taxonomia, rules, issue_patterns), `.env` com variáveis, `MODEL_PROFILES` explícitos | ✅ |
 | **2. Módulos < 400 linhas** | `orchestrator.py` decomposto em 6 módulos, prompts em pacote próprio, pylint `max-module-lines=400` | ✅ |
 | **3. Contract-First** | Pydantic models: `Classification`, `InvestigationContext`, `StructuralAnalysis`, `DeepModel`, `AnalysisResult` | ⚠️ parcial |
-| **4. Testes Determinísticos** | 153 testes com fixtures em memória, respostas LLM mockadas, testes de integração (413/429/fallback) | ✅ |
-| **5. Sistemas Autodescritivos** | `.iac/structure.json`, `.iac/graph.json`, `docs/ARCHITECTURE.md`, docstrings Google style, logging por camada | ✅ |
+| **4. Testes Determinísticos** | 198 testes com fixtures em memória, respostas LLM mockadas, testes de integração e end-to-end do init | ✅ |
+| **5. Sistemas Autodescritivos** | `.iac/structure.json`, `.iac/profile.yaml`, `docs/ARCHITECTURE.md`, docstrings Google style, logging por camada | ✅ |
 | **6. Verificação Automatizada** | `ruff` (lint + docstrings), `pylint` (tamanho), `pytest`, GitHub Actions CI, `.pre-commit-config.yaml` | ✅ |
 
 Scorecard detalhado: [issue #36](https://github.com/jailtoncarlos/incident-analyst-agent/issues/36#issuecomment-4212053047).
@@ -89,7 +89,12 @@ src/iac/
 │
 ├── config/
 │   ├── app_settings.py        # AppSettings — Pydantic Settings + env vars
-│   └── settings.py            # Load/save .iac/ files + config.yaml + .env
+│   └── settings.py            # Load/save .iac/ files, profile.yaml, .env
+│
+├── defaults/                  # Templates genéricos (copiados pelo iac init)
+│   ├── env.template           # Template do .env (todas as variáveis)
+│   ├── profile.yaml           # Defaults de merge (taxonomy + aliases)
+│   └── profile.init.yaml      # Template do profile (vazio com orientações)
 │
 ├── inspector/                 # Camada 1 — Inspeção estrutural
 │   ├── detector.py            # Detecta framework (Django/Flask/FastAPI)
@@ -116,10 +121,10 @@ src/iac/
 │       ├── analysis.py        # Prompt single-prompt (com ajuste progressivo)
 │       ├── multi.py           # Prompts multi-prompt (investigação + evidência)
 │       ├── response.py        # Prompt de relatório técnico para o dev
-│       └── utils.py           # Extração de tipo, taxonomia, compactação
+│       └── utils.py           # Extração de tipo (taxonomia via profile)
 │
 ├── analyzer/
-│   ├── classifier.py          # Classificação sem LLM (origem, app, interessado)
+│   ├── classifier.py          # Classificação sem LLM (genérico, padrões via profile)
 │   └── simulator.py           # Simulação em ambiente controlado (stub — #44)
 │
 ├── integrations/
@@ -136,49 +141,93 @@ src/iac/
         └── app_detail.html    # Detalhe por app
 ```
 
-## Configuração via .env
+## Configuração
 
-Todas as variáveis em `.iac/.env`, carregado automaticamente. CLI args sempre têm prioridade.
+Dois arquivos no `.iac/` do projeto inspecionado:
+
+### `.env` — variáveis de ambiente (tokens, backend, rate limit)
 
 ```bash
-# GitLab
 GITLAB_TOKEN=glpat-...
-
-# LLM Backend (ollama | groq | deepseek | gemini)
 IAC_LLM_BACKEND=groq
 IAC_LLM_MODEL=llama-3.3-70b-versatile
-
-# Rate limit (genérico — aplica para qualquer backend remoto)
-IAC_LLM_RATE_DELAY=30
-IAC_LLM_MAX_RETRIES=3
-
-# API keys por backend
 GROQ_API_KEY=gsk_...
-# DEEPSEEK_API_KEY=sk-...
-# GEMINI_API_KEY=AIza...
-
-# Modo padrão
 IAC_ANALYZE_MODE=multi
+IAC_LLM_RATE_DELAY=30
 ```
 
-Template completo: `.env.example` na raiz do projeto.
+Hierarquia: `.env` → variáveis de ambiente → CLI args (CLI tem prioridade).
+Template completo: `.env.example` na raiz do IAC.
 
-## Artefatos gerados (.iac/)
+### `profile.yaml` — perfil do projeto (genérico, configurável por cliente)
+
+```yaml
+name: "meu-projeto"
+system_description: "Django"
+issue_patterns:                    # Padrões de template de issue
+  title_regex: '^Erro\s+(\d+)...'
+  origin_name: "erro-sistema"
+app_aliases:                       # Nomes no título → app no código
+  Ensino: edu
+url_skip_segments: [djtools]       # Específicos do projeto (além dos defaults)
+rules:                             # Heurísticas injetadas nos prompts
+  - "Se descrição menciona 'prazo', priorize constantes temporais"
+taxonomy:                          # Tipos + aliases (merge com defaults)
+  aliases:
+    tipo::meu-alias: tipo::bug
+```
+
+O `iac init` gera um profile **vazio com orientações**. Seções não definidas usam defaults genéricos do IAC (6 known_tipos, 18 aliases, 5 url_skip_segments).
+
+Merge: `defaults/profile.yaml` (base) + `.iac/profile.yaml` (projeto sobrescreve/amplia):
+- `system_description`, `rules`: projeto sobrescreve
+- `issue_patterns`, `app_aliases`: merge (default + projeto)
+- `url_skip_segments`: **união**
+- `taxonomy.known_tipos`: **união**
+- `taxonomy.aliases`: merge (projeto tem prioridade)
+
+## Artefatos gerados pelo `iac init`
 
 ```
 .iac/
-├── project.json       # Framework, versão, settings
-├── structure.json     # Mapa de apps/views/models/forms/admin/urls
-├── graph.json         # Grafo de dependências (arestas tipadas)
-├── config.yaml        # Configurações persistentes (opcional, .env preferido)
-├── .env               # Variáveis de ambiente (não commitado)
-├── logs/
-│   ├── iac_YYYYMMDD_HHMMSS.log  # Log DEBUG por execução
-│   └── groq/                     # Logs de bateria Groq
-└── diagrams/
-    ├── overview.html   # Visão geral dos apps
-    └── *.html          # Detalhe por app
+├── project.json           # Framework, versão, settings (inspeção)
+├── structure.json         # Mapa de apps/views/models/forms/admin/urls
+├── graph.json             # Grafo de dependências (arestas tipadas)
+├── .env                   # Template de configuração (comentado)
+├── profile.yaml           # Perfil do projeto (vazio com orientações)
+├── logs/                  # Diretório para logs de execução
+│   └── iac_YYYYMMDD_HHMMSS.log
+└── diagrams/              # Visualizações interativas D3.js
+    ├── overview.html      # Visão geral dos apps
+    └── {app}.html         # Detalhe por app detectado
 ```
+
+## Primeira execução (`iac init`)
+
+```bash
+$ cd /caminho/do/meu-projeto
+$ iac init
+Inspecionando /caminho/do/meu-projeto...
+Inspeção concluída: Django 5.2 — 15 apps, 120 views, 85 models
+  → .iac/.env (template de configuração)
+  → .iac/profile.yaml (perfil do projeto — customize para seu sistema)
+  → .iac/diagrams/ (16 visualizações interativas)
+```
+
+Após o init, o operador edita `.iac/.env` (tokens, backend LLM) e `.iac/profile.yaml` (padrões de issue, app_aliases, rules, taxonomy do seu projeto).
+
+### Testes do init (22 testes)
+
+| Artefato | Teste unitário | Teste E2E |
+|----------|---------------|-----------|
+| `.env` | gerado com variáveis, não sobrescreve | todas as variáveis presentes |
+| `profile.yaml` | vazio, com orientações, nome do projeto | seções vazias, comentários |
+| `project.json` | — | existe |
+| `structure.json` | — | existe com apps detectados |
+| `graph.json` | — | existe com edges |
+| `logs/` | criado | existe |
+| `diagrams/overview.html` | — | existe |
+| `diagrams/{app}.html` | — | por app detectado |
 
 ## Backends LLM
 
@@ -217,14 +266,19 @@ Template completo: `.env.example` na raiz do projeto.
 | Repair prompt | Se resposta tem análise mas não classificou, pede só CLASSIFICAÇÃO |
 | `_enrich_on_repeat()` | Máximo 4 métodos focais quando LLM repete investigação |
 
-### Taxonomia
+### Taxonomia (configurável via profile.yaml)
 
-Labels conhecidos (`KNOWN_TIPOS`): `bug`, `configuracao`, `dados-cadastrais`, `prazo-expirado`, `nao-e-erro`.
+Labels conhecidos (defaults): `bug`, `configuracao`, `dados-cadastrais`, `prazo-expirado`, `nao-e-erro`, `permissao`.
 
-Aliases (`_LABEL_ALIASES`): labels criativos do LLM são normalizados para o catálogo:
-- `avaliacao-nao-disponivel` → `prazo-expirado`
-- `logica-incorreta` → `bug`
-- `acesso-negado` → `permissao`
+Aliases (defaults, 18 mapeamentos): labels criativos do LLM são normalizados:
+- `avaliacao-nao-disponivel`, `tempo-expirado`, `tempo-habil-para-avaliacao` → `prazo-expirado`
+- `logica-incorreta`, `validacao-falhada`, `erro-de-codigo` → `bug`
+- `comportamento-esperado` → `nao-e-erro`
+- `acesso-negado`, `sem-permissao` → `permissao`
+
+O parser aceita labels **com ou sem** prefixo `tipo::` (ex: `bug` → `tipo::bug`).
+
+Clientes podem adicionar tipos e aliases no `profile.yaml → taxonomy`.
 
 ## Tipos de aresta no grafo
 
@@ -277,7 +331,7 @@ Detalhes: [issue #15](https://github.com/jailtoncarlos/incident-analyst-agent/is
 Formato por camada, gravado em `.iac/logs/iac_YYYYMMDD_HHMMSS.log` (DEBUG) e terminal (INFO):
 
 ```
-[Camada 1] Classifier — origem=erro-suap, app=progressao_docente
+[Camada 1] Classifier — origem=erro-sistema, app=loja
 [Camada 2] Orchestrator — 12 calls, 2 refs, 13 passos
 [Camada 3] Structural — 2 models, 1 templates, 6 passos no fluxo
 [Camada 4] Deep — 11 models em profundidade
@@ -292,7 +346,7 @@ Formato por camada, gravado em `.iac/logs/iac_YYYYMMDD_HHMMSS.log` (DEBUG) e ter
 - **Lint:** `ruff` com 11 categorias de regras (E, F, W, I, N, UP, S, B, SIM, PIE, D)
 - **Docstrings:** Google convention obrigatória (`pydocstyle`)
 - **Tamanho de módulo:** `pylint` com `max-module-lines=400` (`.pylintrc`)
-- **Testes:** 153 testes (unitários + integração + regressão)
+- **Testes:** 198 testes (unitários + integração + regressão + E2E do init)
 - **CI:** GitHub Actions (ruff + pylint + pytest em cada push)
 - **Pre-commit:** `ruff-format` + `ruff check` + `pylint` (tamanho de módulo)
 
@@ -300,8 +354,8 @@ Formato por camada, gravado em `.iac/logs/iac_YYYYMMDD_HHMMSS.log` (DEBUG) e ter
 
 | Milestone | Estado | Issues |
 |-----------|--------|--------|
-| [v0.1 — Inspeção e Análise](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/1) | ✅ fechada | 18 fechadas |
-| [v0.2 — Qualidade da Análise LLM](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/3) | em aberto | #7, #39, #50, #52, #53, #54 |
+| [v0.1 — Inspeção e Análise](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/1) | ✅ fechada | 19 fechadas |
+| [v0.2 — Qualidade da Análise LLM](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/3) | em aberto | #7, #39, #50, #58, #62, #64 |
 | [v0.3 — Simulação e Verificação](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/4) | em aberto | #4, #6, #8, #44, #59, #60 |
 | [v0.4 — Aprendizado (RAG)](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/5) | em aberto | #55 |
 | [v1.0 — Chatbot Conversacional](https://github.com/jailtoncarlos/incident-analyst-agent/milestone/6) | em aberto | #56 |
@@ -310,10 +364,10 @@ Formato por camada, gravado em `.iac/logs/iac_YYYYMMDD_HHMMSS.log` (DEBUG) e ter
 ## Evolução planejada
 
 ```
-Atual:  Inspeção direta + LLM (4 backends, 4 modos, guardrails)
-v0.2:   Melhorar análise LLM (loop fechamento, multi parse, taxonomia)
-v0.3:   + Simulação no banco (#44) + Relatório unificado (#60)
-v0.4:   + RAG com 8.398 issues do SUAP (#55)
+Atual:  Core genérico + profile.yaml por cliente + 4 backends + 4 modos + guardrails
+v0.2:   Melhorar análise LLM (#58 DeepSeek, #62 core genérico, #64 hardcoded restantes)
+v0.3:   + Simulação no banco (#44) + Relatório unificado (#60) + Gemini produção (#59)
+v0.4:   + RAG com issues já respondidas (#55)
 v1.0:   + Chatbot conversacional (#56)
 Futuro: + Fine-tuning / DPO quando dataset suficiente (#55)
 ```

--- a/docs/catalogo-llms-2026-codex.md
+++ b/docs/catalogo-llms-2026-codex.md
@@ -1,0 +1,481 @@
+Relatório gerado em [docs/catalogo-llms-2026-codex.md](/home/jailton/workspace/incident-analyst-agent/docs/catalogo-llms-2026-codex.md).
+
+O arquivo tem 489 linhas e cobre o escopo pedido: tabela mestre, classificação por custo/especialização/proveniência/origem/tamanho, custos por análise IAC, projeções mensais, gráfico ASCII, rankings por caso de uso, matriz ponderada, riscos, recomendações e metodologia. Também marquei explicitamente com `⚠️ não verificado` os pontos em que não encontrei dado oficial confiável, especialmente preços diretos de alguns modelos open-weights ou legados.
+
+Usei web search e deixei as fontes no próprio relatório, priorizando páginas oficiais como OpenAI, Anthropic, Google Gemini, DeepSeek, Mistral, xAI, Cohere, AI21, Alibaba/Qwen, MiniMax, Groq, Together, Fireworks, OpenRouter, Hugging Face, Replicate e Perplexity. O arquivo está não rastreado no Git (`?? docs/catalogo-llms-2026-codex.md`).
+ / Qwen3 32B | Custo por análise abaixo de US$0,004 em alguns casos; latência boa. |
+| Produção balanceada | Gemini 2.5 Flash | GPT-4.1 mini / Haiku 4.5 | Bom código, multimodal, 1M contexto, preço baixo. |
+| Produção premium | Claude Sonnet 4.6 | GPT-4.1 / o3 / Gemini 2.5 Pro | Melhor equilíbrio para código, debugging e relatórios longos. |
+| Casos críticos | Claude Opus 4.6 | o3 / Gemini 2.5 Pro | Máxima qualidade, custo secundário. |
+
+## Premissas e caveats
+
+- Modelos open-weights não têm preço oficial único: o custo depende do provedor, GPU, região e quantização. Quando não há preço oficial do criador do modelo, uso preço de provedor hospedado e marco isso.
+- “Gratuito permanente” raramente significa produção grátis. Em geral é quota pequena, roteamento variável ou uso sujeito a coleta de dados.
+- Latência pública é inconsistente. Uso números oficiais quando existem; caso contrário marco `⚠️ não verificado`.
+- “Open-source completo” é raro. Llama, Qwen, DeepSeek, Mistral e Kimi têm pesos públicos ou licenças abertas, mas nem sempre OSI-open-source.
+- Preços mudam com frequência; os riscos são maiores em agregadores e modelos “preview”.
+
+## Fórmula de custo IAC
+
+```text
+custo_por_analise = (0,008 * preço_input_1M) + (0,002 * preço_output_1M)
+custo_BRL = custo_USD * 4,9905
+```
+
+## Tabela mestre
+
+Legenda de qualidade: ★ fraco, ★★ aceitável, ★★★ bom, ★★★★ muito bom, ★★★★★ frontier.  
+API: `OA` = OpenAI-compatible, `Nativa` = SDK/API própria.
+
+| Modelo | Provedor/API | Origem | Tipo | Contexto | Tamanho/arquitetura | Input | Output | IAC US$ | Qual. IAC | API | Observações |
+|---|---|---:|---|---:|---|---:|---:|---:|---:|---|---|
+| GPT-4o | OpenAI | EUA | proprietário, multimodal | 128K | closed/dense? | 2.50 | 10.00 | 0.0400 | ★★★★ | Nativa/OA | Legado útil; API mantida, ChatGPT aposentou. |
+| GPT-4o mini | OpenAI | EUA | proprietário, baixo custo | 128K | closed | 0.15 | 0.60 | 0.0024 | ★★★ | Nativa/OA | Excelente triagem barata. |
+| GPT-4.1 | OpenAI | EUA | proprietário, código | 1.05M | closed | 2.00 | 8.00 | 0.0320 | ★★★★ | Nativa/OA | Forte em código; SWE-bench Verified 54,6% divulgado. |
+| o3 | OpenAI | EUA | proprietário, reasoning | ⚠️ não verificado | closed | 2.00 | 8.00 | 0.0320 | ★★★★★ | Nativa/OA | Melhor quando há análise causal difícil. |
+| o3-mini | OpenAI | EUA | proprietário, reasoning barato | ⚠️ não verificado | closed | 1.10 | 4.40 | 0.0176 | ★★★★ | Nativa/OA | Boa opção de fallback reasoning. |
+| o1 | OpenAI | EUA | proprietário, reasoning premium legado | ⚠️ não verificado | closed | 15.00 | 60.00 | 0.2400 | ★★★★ | Nativa/OA | Caro; evitar salvo compatibilidade antiga. |
+| Codex mini / GPT Codex | OpenAI | EUA | code-specialized | 256K-? | closed | 1.50 | 6.00 | 0.0240 | ★★★★ | Nativa/OA | Para edição/agentes de código; há variantes GPT-5.1 Codex mini mais baratas. |
+| Claude Opus 4.6 | Anthropic | EUA | proprietário, reasoning/código | 1M beta | closed | 5.00 | 25.00 | 0.0900 | ★★★★★ | Nativa | Premium; melhor para issues críticas. |
+| Claude Sonnet 4.6 | Anthropic | EUA | proprietário, coding/agentic | 1M beta | closed | 3.00 | 15.00 | 0.0540 | ★★★★★ | Nativa | Melhor default premium para IAC. |
+| Claude Haiku 4.5 | Anthropic | EUA | proprietário, rápido | ⚠️ não verificado | closed | 1.00 | 5.00 | 0.0180 | ★★★★ | Nativa | Boa triagem com qualidade acima do preço. |
+| Gemini 2.5 Pro | Google | EUA | proprietário, multimodal/reasoning | 1M | closed | 1.25 | 10.00 | 0.0300 | ★★★★★ | Nativa/OA parcial | Ótimo long-context; output caro. |
+| Gemini 2.5 Flash | Google | EUA | proprietário, baixo custo/reasoning | 1M | closed | 0.30 | 2.50 | 0.0074 | ★★★★ | Nativa/OA parcial | Melhor custo-benefício geral. |
+| Gemini 2.0 Flash | Google | EUA | proprietário, multimodal barato | 1M | closed | 0.10 | 0.40 | 0.0016 | ★★★ | Nativa/OA parcial | Fortíssimo para volume e testes pagos. |
+| Llama 3.3 70B | Meta via Groq/Together | EUA | open-weights | 128K | 70B dense | 0.59-0.88 | 0.79-0.88 | 0.0063-0.0088 | ★★★ | OA via provedor | Boa alternativa barata; menos forte que Sonnet/GPT em RCA complexo. |
+| Llama 3.1 405B | Meta via provedores | EUA | open-weights | 128K | 405B dense | variável | variável | ⚠️ | ★★★★ | OA via provedor | Peso público; caro de hospedar. |
+| Llama 3.1 70B | Meta via provedores | EUA | open-weights | 128K | 70B dense | variável | variável | ⚠️ | ★★★ | OA via provedor | Superado por 3.3 70B na maioria dos usos. |
+| Llama 3.1 8B | Meta via Groq/local | EUA | open-weights, small | 128K | 8B dense | 0.05 | 0.08 | 0.0006 | ★★ | OA/local | Bom para testes, ruim para análise causal profunda. |
+| Llama 4 Scout | Meta via Groq/Together | EUA | open-weights, multimodal | 10M | MoE 109B total/17B ativo | 0.11 | 0.34 | 0.0016 | ★★★★ | OA via provedor | Muito interessante para contexto enorme. |
+| Llama 4 Maverick | Meta via provedores | EUA | open-weights, multimodal | 1M | MoE ~400B/17B ativo | variável | variável | ⚠️ | ★★★★ | OA via provedor | Mais forte que Scout; disponibilidade/preço variam. |
+| Mistral Large 2.1 | Mistral | Europa | proprietário legado | 128K | closed | 2.00 | 6.00 | 0.0280 | ★★★★ | Nativa/OA | Legado; Large 3 é open-weight mais novo. |
+| Mistral Medium 3.1 | Mistral | Europa | proprietário | ⚠️ | closed | ⚠️ | ⚠️ | ⚠️ | ★★★★ | Nativa/OA | Preço oficial não verificado no crawl; modelo recomendado pela Mistral. |
+| Mistral Small 4 | Mistral | Europa | open-weights, hybrid | 256K | MoE 119B/6.5B ativo | 0.15 | 0.60 | 0.0024 | ★★★★ | Nativa/OA | Forte opção europeia e barata. |
+| Mixtral 8x7B | Mistral/Together | Europa | open-weights | 32K | MoE ~47B/13B ativo | 0.60 | 0.60 | 0.0060 | ★★ | OA via provedor | Legado; evitar para IAC moderno. |
+| Mixtral 8x22B | Mistral/Fireworks | Europa | open-weights | 64K | MoE ~141B/39B ativo | ~1.20 | ~1.20 | 0.0120 | ★★★ | OA via provedor | Ainda útil, mas superado por Small 4/DeepSeek. |
+| Codestral 25.08 | Mistral | Europa | code-specialized | 128K | closed/premier | 0.30 | 0.90 | 0.0042 | ★★★★ | Nativa/OA | Bom para FIM/código; não é melhor RCA geral. |
+| DeepSeek V3/V3.1 | DeepSeek/provedores | China | open-weights | 64K-128K | MoE 671B/37B ativo | 0.28-0.60 | 0.42-1.70 | 0.0031-0.0082 | ★★★★ | OA | Excelente custo/qualidade; cautela LGPD. |
+| DeepSeek Coder | DeepSeek/provedores | China | open-weights, código | variável | variável | ⚠️ | ⚠️ | ⚠️ | ★★★★ | OA/local | Bom local; preço oficial atual não verificado. |
+| DeepSeek Reasoner/R1 | DeepSeek | China | open-weights/reasoning | 128K | MoE | 0.28-0.55 | 0.42-2.19 | 0.0031-0.0088 | ★★★★★ | OA | Muito bom em custo; output reasoning pode inflar. |
+| Qwen 2.5 72B | Alibaba/provedores | China | open-weights | 128K | 72B dense | variável | variável | ⚠️ | ★★★★ | OA/local | Bom para código e pt-BR; preço depende do host. |
+| Qwen 2.5 32B | Alibaba/provedores | China | open-weights | 128K | 32B dense | variável | variável | ⚠️ | ★★★ | OA/local | Ótimo local/baixo custo. |
+| Qwen 2.5 14B | Alibaba/provedores | China | open-weights | 128K | 14B dense | variável | variável | ⚠️ | ★★ | OA/local | Testes e dev local. |
+| Qwen 2.5 7B | Alibaba/provedores | China | open-weights | 128K | 7B dense | 0.30 Together | 0.30 | 0.0030 | ★★ | OA/local | Apenas triagem simples. |
+| Qwen3 32B | Groq/Alibaba/provedores | China | open-weights/reasoning | 131K | 32B dense | 0.29 Groq | 0.59 | 0.0035 | ★★★★ | OA via provedor | Bom custo e latência no Groq. |
+| Qwen3 235B | Alibaba/provedores | China | open-weights/MoE | 128K+ | MoE 235B/A22B | variável | variável | ⚠️ | ★★★★ | OA | Forte; preço oficial por variante DashScope é confuso. |
+| Qwen-Coder | Alibaba | China | code-specialized | até 1M em qwen3-coder | MoE/dense por versão | 1.00+ | 5.00+ | 0.0180+ | ★★★★ | OA | Caro em janelas longas; bom em agentic coding. |
+| QwQ | Alibaba/provedores | China | reasoning | 32K-128K | 32B | variável | variável | ⚠️ | ★★★ | OA/local | Superado por Qwen3 reasoning/DeepSeek R1. |
+| MiniMax abab6.5 | MiniMax | China | proprietário legado | ⚠️ | closed | ⚠️ | ⚠️ | ⚠️ | ★★★ | OA parcial | Legado; docs atuais priorizam M2.x. |
+| MiniMax M1 | MiniMax | China | open-weight reasoning | 1M | MoE 456B/45.9B ativo | 0.40* | 2.20* | 0.0076 | ★★★★ | OA/Anthropic compat | *Preço não oficial direto; pesos e specs oficiais. |
+| MiniMax M2.5 | MiniMax | China | proprietário, código/agentic | 204.8K | closed | 0.30 Fireworks/Together | 1.20 | 0.0048 | ★★★★ | OA/Anthropic compat | Docs oficiais confirmam 60-100 tps. |
+| Grok 2 | xAI | EUA | proprietário legado | ⚠️ | closed | ⚠️ | ⚠️ | ⚠️ | ★★★ | OA | Substituído por Grok 3/4. |
+| Grok 3 | xAI | EUA | proprietário | 131K | closed | 3.00 | 15.00 | 0.0540 | ★★★★ | OA | Mesmo preço de Sonnet; menos atraente para IAC. |
+| Grok 4 | xAI | EUA | proprietário reasoning | 256K | closed | 3.00 | 15.00 | 0.0540 | ★★★★ | OA | Bom, mas Grok 4.20/4.1 Fast já mudaram o cenário. |
+| Grok 4.20 | xAI | EUA | proprietário agentic | 2M | closed | 2.00 | 6.00 | 0.0280 | ★★★★ | OA | Atual flagship listado pela xAI; incluir como sucessor prático. |
+| Cohere Command R+ | Cohere | Canadá/EUA | proprietário RAG/tool | 128K | closed | 2.50 | 10.00 | 0.0400 | ★★★ | Nativa | Forte em RAG/citações; caro frente a Flash. |
+| Cohere Command R | Cohere | Canadá/EUA | proprietário RAG barato | 128K | closed | 0.15 | 0.60 | 0.0024 | ★★★ | Nativa | Bom para extração e RAG simples. |
+| AI21 Jamba 1.5 Large | AI21 | Israel | open-weights | 256K | hybrid SSM-Transformer MoE 398B/94B | 2.00 | 8.00 | 0.0320 | ★★★ | Nativa/Bedrock | Long-context bom; ecossistema menor. |
+| AI21 Jamba 1.5 Mini | AI21 | Israel | open-weights | 256K | hybrid MoE 52B/12B | 0.20 | 0.40 | 0.0024 | ★★★ | Nativa/Bedrock | Barato, bom para documentos longos simples. |
+| Zhipu GLM-4/4.5 | Zhipu | China | open/proprietário por versão | 128K | GLM-4.5 MoE 355B/32B | 0.60* | 2.20* | 0.0092 | ★★★★ | OA | *Preço de agregador; confirmar no console oficial. |
+| Moonshot Kimi K2 | Moonshot | China | open-weights/MoE | 128K-256K | 1T/32B ativo | 0.15-0.60 | 2.00-2.50 | 0.0062 | ★★★★ | OA/Anthropic compat | Bom para agentes/código; origem China. |
+| 01.AI Yi | 01.AI | China | open-weights | 32K-200K | 6B-34B+ | ⚠️ | ⚠️ | ⚠️ | ★★ | OA via host | Menos relevante em 2026; evitar salvo legado/local. |
+
+Fontes principais do bloco: OpenAI pricing/model docs, Anthropic pricing/news/rate-limit docs, Google Gemini pricing, Groq pricing, Together pricing, Fireworks pricing, DeepSeek docs, Mistral docs, Cohere docs, AI21 pricing/research, xAI docs/API page, Alibaba Model Studio pricing, MiniMax docs/news, Meta/Hugging Face model cards, OpenRouter pricing/rate limits, Hugging Face pricing, Replicate pricing, Perplexity pricing.
+
+## Dados por família e fontes
+
+### OpenAI
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| GPT-4o | 2024; mantido na API | Sem free API permanente verificável; limites por tier no console | 128K | ⚠️ não verificado | ⚠️ | Multimodal, robusto, maduro | Custo maior que GPT-4.1 mini/Gemini Flash. |
+| GPT-4o mini | 2024 | Sem free API permanente verificável | 128K | ⚠️ | ⚠️ | Muito barato, bom para triagem | Fraco para RCA complexo. |
+| GPT-4.1 | 14/04/2025 | Sem free API permanente verificável | 1.047.576 | baixa, sem reasoning step | SWE-bench Verified 54,6% | Código, instrução, long-context | Não é reasoning profundo. |
+| o3/o3-mini/o1 | 2024-2025 | Sem free API permanente verificável | ⚠️ | Mais lenta por reasoning | ⚠️ | Raciocínio e investigação | Pode gerar custo oculto por reasoning tokens. |
+| Codex | 2025+ | Sem free API permanente verificável | ⚠️ | ⚠️ | ⚠️ | Edição e agentes de código | Nome/modelos mudam; pinagem necessária. |
+
+Qualidade IAC: GPT-4.1 e o3 são fortes para stack trace/código; GPT-4o mini é triagem econômica; o1 é caro e hoje tende a ser substituído por o3/GPT-5.x.  
+Fontes: [OpenAI API Pricing](https://openai.com/api/pricing/), [OpenAI pricing docs](https://platform.openai.com/docs/pricing/), [GPT-4.1 model](https://platform.openai.com/docs/models/gpt-4.1), [GPT-4o model](https://platform.openai.com/docs/models/gpt-4o), [GPT-4o mini model](https://developers.openai.com/api/docs/models/gpt-4o-mini), [GPT-4.1 release](https://openai.com/index/gpt-4-1/), [OpenAI rate limits](https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits).
+
+### Anthropic
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| Claude Opus 4.6 | 05/02/2026 | API exige crédito; Tier 1 após compra de US$5 | 1M beta | ⚠️ | SWE-bench Verified até 81,42% com prompt modificado; Terminal-Bench 2.0 líder | Melhor para RCA crítico, code review, agentes longos | Custo alto. |
+| Claude Sonnet 4.6 | 17/02/2026 | Claude.ai Free tem acesso; API tier por crédito | 1M beta | ⚠️ | SWE-bench Verified citado por imprensa em 79,6%; confirmar system card | Melhor default premium para IAC | Ainda caro em volume alto. |
+| Claude Haiku 4.5 | 2025 | API tier por crédito | ⚠️ | rápido | ⚠️ | Triagem, resumo, extração | Menos confiável em debugging profundo. |
+
+Rate limits Tier 1: 50 RPM para Opus/Sonnet 4.x, 30K ITPM, 8K OTPM; tiers sobem por crédito comprado.  
+Fontes: [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing), [Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6), [Claude Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6), [Anthropic rate limits](https://docs.anthropic.com/en/api/rate-limits), [Choosing Claude models](https://claude.com/resources/tutorials/choosing-the-right-claude-model).
+
+### Google Gemini
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| Gemini 2.5 Pro | 2025 | Free tier no AI Studio; dados podem melhorar produtos | 1M | ⚠️ | ⚠️ | Long-context, código, reasoning | Output caro; quota free não é produção. |
+| Gemini 2.5 Flash | 2025 | Free tier; Search grounding até 500 RPD no free | 1M | rápida | ⚠️ | Melhor custo-benefício geral | Menos consistente que Sonnet em RCA difícil. |
+| Gemini 2.0 Flash | 2024/2025 | Free tier; Search grounding até 500 RPD | 1M | rápida | ⚠️ | Barato, multimodal, bom para volume | Qualidade menor em bugs complexos. |
+
+Fontes: [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing), [Gemini pricing](https://ai.google.dev/pricing).
+
+### Meta Llama
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| Llama 3.3 70B | 06/12/2024 | Grátis local; provedores podem ter free endpoints | 128K | Groq 394 tps | MMLU/benchmarks no model card | Bom open-weight geral | Menos preciso que frontier closed. |
+| Llama 3.1 405B/70B/8B | 23/07/2024 | Grátis local/pesos | 128K | depende do host | MMLU 85,2 para 405B base divulgado | Open-weight, deploy privado | 405B caro; 8B fraco. |
+| Llama 4 Scout | 05/04/2025 | Grátis local/pesos; via Groq pago | 10M | Groq 594 tps | ⚠️ | Contexto enorme, multimodal, baixo custo | 10M real em produção depende do host. |
+| Llama 4 Maverick | 05/04/2025 | Grátis local/pesos | 1M | ⚠️ | ⚠️ | Melhor qualidade Llama 4 | Preço/disponibilidade variam. |
+
+Fontes: [Llama 3.1 HF](https://huggingface.co/meta-llama/Llama-3.1-405B), [Llama 3.3 NVIDIA card](https://build.nvidia.com/meta/llama-3_3-70b-instruct/modelcard), [Llama 4 HF docs](https://huggingface.co/docs/transformers/en/model_doc/llama4), [Llama 4 Scout HF](https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E), [Llama 4 Maverick HF](https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E), [Groq pricing](https://groq.com/pricing), [Together pricing](https://www.together.ai/pricing).
+
+### Mistral AI
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| Mistral Large / Large 2.1 | 2024 legado | Le Chat free; API sem free produção | 128K | ⚠️ | ⚠️ | Boa qualidade geral, Europa | Legado vs Large 3/Small 4. |
+| Mistral Medium 3.1 | 08/2025 | ⚠️ | ⚠️ | ⚠️ | ⚠️ | Multimodal frontier Mistral | Preço oficial não capturado. |
+| Mistral Small 4 | 16/03/2026 | pesos abertos | 256K | ⚠️ | ⚠️ | Barato, open, Europa, híbrido reasoning/coding | Ainda validar em RCA IAC. |
+| Mixtral 8x7B/8x22B | 2023/2024 | pesos abertos | 32K/64K | ⚠️ | ⚠️ | Barato/local | Obsoleto para produção IAC. |
+| Codestral | 30/07/2025 | ⚠️ | 128K | baixa | ⚠️ | FIM, geração/correção de código | Especializado; relatórios RCA podem ser piores. |
+
+Fontes: [Mistral models](https://docs.mistral.ai/getting-started/models), [Mistral Small 4](https://docs.mistral.ai/models/mistral-small-4-0-26-03), [Codestral 25.08](https://docs.mistral.ai/models/codestral-25-08), [Fireworks pricing](https://fireworks.ai/pricing), [Together pricing](https://www.together.ai/pricing).
+
+### DeepSeek
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| DeepSeek V3/V3.1 | 2024/2025 | Sem free oficial robusto; pesos públicos | 64K-128K | ⚠️ | ⚠️ | Custo muito baixo, bom código | Compliance China; versões API/app divergem. |
+| DeepSeek Coder | 2024/2025 | local | variável | depende local | ⚠️ | Código barato/local | Menos generalista. |
+| DeepSeek Reasoner/R1 | 2025; API atual mapeia V3.2 thinking | 128K | 128K | ⚠️ | ⚠️ | Reasoning barato, OA-compatible | CoT/output pode aumentar custo; política de dados. |
+
+Fontes: [DeepSeek pricing](https://api-docs.deepseek.com/quick_start/pricing/), [DeepSeek pricing details](https://api-docs.deepseek.com/quick_start/pricing-details-usd/), [DeepSeek API overview](https://api-docs.deepseek.com/), [DeepSeek reasoner](https://api-docs.deepseek.com/guides/reasoning_model), [Together DeepSeek](https://www.together.ai/models-providers/deepseek).
+
+### Alibaba Qwen
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| Qwen 2.5 72B/32B/14B/7B | 2024/2025 | pesos abertos; Alibaba dá quotas por 90 dias em alguns modelos | 128K típico | depende host | ⚠️ | Código, multilíngue, local | Preço oficial por nome open-weight não é único. |
+| Qwen3 32B/235B | 2025 | pesos abertos/quotas DashScope por modelo | 128K-1M por variante | Groq 662 tps para Qwen3 32B | ⚠️ | Bom reasoning/código barato | Políticas e preços variam por região. |
+| Qwen-Coder | 2025 | quota 1M tokens por 90 dias em Alibaba International | até 1M | ⚠️ | ⚠️ | Código/agentic | Custo sobe em contexto longo. |
+| QwQ | 2024/2025 | pesos abertos | 32K+ | ⚠️ | ⚠️ | Reasoning local | Superado por Qwen3/DeepSeek. |
+
+Fontes: [Alibaba Model Studio pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing), [Alibaba billing](https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio), [Groq pricing](https://groq.com/pricing), [Together pricing](https://www.together.ai/pricing).
+
+### MiniMax
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| abab6.5 | legado | ⚠️ | ⚠️ | ⚠️ | ⚠️ | Compatibilidade histórica | Não é foco atual da plataforma. |
+| M1 | 16/06/2025 | pesos abertos | 1M | ⚠️ | ⚠️ | Reasoning longo, open-weight | Preço oficial API não capturado; usar host. |
+| M2.5/M2.7 | 2026 | ⚠️ | 204.8K | 60 tps; highspeed 100 tps | ⚠️ | Código/agentic, boa latência | Menor maturidade de ecossistema no Brasil. |
+
+Fontes: [MiniMax API overview](https://platform.minimax.io/docs/api-reference/api-overview), [MiniMax text generation](https://platform.minimax.io/docs/guides/text-generation), [MiniMax M1 news](https://www.minimax.io/news/minimaxm1), [MiniMax M1 GitHub](https://github.com/MiniMax-AI/MiniMax-M1), [Fireworks pricing](https://fireworks.ai/pricing), [Together pricing](https://www.together.ai/pricing).
+
+### xAI
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| Grok 2 | legado | ⚠️ | ⚠️ | ⚠️ | ⚠️ | Integração X/ecossistema | Evitar em novo backend. |
+| Grok 3 | 2025 | sem free API claro | 131K | ⚠️ | ⚠️ | Geral forte | Mesmo custo de Sonnet 4.6 com menor confiança para IAC. |
+| Grok 4 | 2025 | sem free API claro | 256K | ⚠️ | ⚠️ | Reasoning | Substituído operacionalmente por 4.20/4.1 Fast. |
+| Grok 4.20 / 4.1 Fast | 2026 | sem free API claro | 2M | “lightning fast” oficial, sem tps | ⚠️ | Contexto 2M e tool calling | Modelo muda rápido; pinagem necessária. |
+
+Fontes: [xAI API](https://x.ai/api), [xAI models and pricing](https://docs.x.ai/docs/models), [xAI rate limits](https://docs.x.ai/developers/rate-limits), [xAI consumption](https://docs.x.ai/docs/key-information/consumption-and-rate-limits).
+
+### Cohere e AI21
+
+| Modelo | Lançamento/atualização | Free tier | Contexto | Latência | Benchmarks | Forças | Fraquezas |
+|---|---|---|---:|---|---|---|---|
+| Command R+ | 08/2024 | Trial key no dashboard | 128K | 25% menor que versão anterior | ⚠️ | RAG, citações, tool-use | Custo alto para IAC simples. |
+| Command R | 08/2024 | Trial key | 128K | 20% menor que versão anterior | ⚠️ | RAG barato | Código/debugging mediano. |
+| Jamba 1.5 Large | 22/08/2024 | US$10 créditos/3 meses | 256K | AI21 cita até 2,5x em long context | Arena/benchmarks gerais | Long-context e híbrido SSM | Menor comunidade. |
+| Jamba 1.5 Mini | 22/08/2024 | US$10 créditos/3 meses | 256K | rápida | Arena Hard 46,1 citado pela AWS | Barato para documentos | Menos forte em código. |
+
+Fontes: [Command R+](https://docs.cohere.com/v2/docs/command-r-plus), [Command R](https://docs.cohere.com/docs/command-r), [Cohere pricing](https://cohere.com/pricing), [AI21 pricing](https://www.ai21.com/pricing/), [AI21 Jamba research](https://www.ai21.com/research/jamba-1-5-hybrid-transformer-mamba-models-at-scale/), [AWS Jamba Large](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-ai21-labs-jamba-1-5-large.html).
+
+### Provedores multi-modelo
+
+| Provedor | Free/crédito | Preço/observação | Forças | Fraquezas |
+|---|---|---|---|---|
+| Groq | console/free tier variável; não usar como garantia | Llama 4 Scout US$0,11/0,34; Qwen3 32B US$0,29/0,59; Llama 3.3 70B US$0,59/0,79 | Latência extrema, OpenAI-compatible | Catálogo menor; rate limits por conta. |
+| Together.ai | sem free robusto verificado | DeepSeek V3.1 US$0,60/1,70; R1 US$3/7; Llama 3.3 70B US$0,88/0,88 | Bom catálogo open-weights | Mais caro que API direta em alguns modelos. |
+| Fireworks | US$1 crédito inicial | DeepSeek V3 family US$0,56/1,68; MiniMax 2.5 US$0,30/1,20; tiers por tamanho | Ótimo para open models e batch 50% | Preço por família pode ocultar variante. |
+| OpenRouter | 25+ modelos free, 50 req/dia; paid sem markup declarado | 5,5% platform fee em PAYG; free router 0/0 | Fallback/roteamento e catálogo enorme | Variabilidade de privacidade, latência e provider. |
+| HuggingFace Inference | US$0,10/mês free; Pro US$2/mês | Pay-as-you-go por provider ou compute-time | Bom para protótipo e self-host | Crédito free simbólico. |
+| Replicate | sem free destacado | Por segundo de hardware ou por token em modelos selecionados | Fácil para modelos públicos/custom | Custo variável; LLMs nem sempre baratos. |
+| Perplexity API | sem free robusto verificado | Sonar US$1/1; Sonar Pro US$3/15 + taxa por busca | Busca/web factual | Não é ideal para stack trace privado sem web. |
+
+Fontes: [Groq pricing](https://groq.com/pricing), [Together pricing](https://www.together.ai/pricing), [Fireworks pricing](https://fireworks.ai/pricing), [OpenRouter pricing](https://openrouter.ai/pricing), [OpenRouter rate limits](https://openrouter.zendesk.com/hc/en-us/articles/39501163636379-OpenRouter-Rate-Limits-What-You-Need-to-Know), [OpenRouter free](https://openrouter.ai/openrouter/free), [Hugging Face pricing](https://huggingface.co/docs/api-inference/en/pricing), [Replicate pricing](https://replicate.com/pricing), [Perplexity pricing](https://docs.perplexity.ai/docs/getting-started/pricing).
+
+### Chineses adicionais
+
+| Família | Estado 2026 | Forças | Fraquezas | Verificação |
+|---|---|---|---|---|
+| Zhipu GLM-4/GLM-4.5 | GLM-4.5 aparece como MoE 355B/32B, 128K, MIT em fontes públicas; preço direto oficial não capturado | Agentic, tool-use, open-ish | Compliance China; preço precisa confirmar no console | ⚠️ preço não verificado oficialmente |
+| Moonshot Kimi K2/K2.5 | API oficial lista K2/K2.5, 256K em variantes, K2 MoE 1T/32B | Agentes, código, bom custo | Política China; preços variam por variante | Parcialmente verificado |
+| 01.AI Yi | Família open-weight relevante em 2024; menor relevância em 2026 | Local, pesos públicos | Qualidade inferior aos líderes atuais | ⚠️ preço/API atual não verificado |
+
+Fontes: [Kimi pricing docs](https://platform.moonshot.ai/docs/pricing/chat), [Kimi overview](https://platform.moonshot.ai/docs/overview), [GLM-4.5 public page](https://glm45.org/), [GLM pricing aggregator](https://lmmarketcap.com/pricing-page/model/z-ai-glm-4-5).
+
+## Classificação por custo
+
+| Faixa | Modelos |
+|---|---|
+| Gratuito permanente | Ollama/local: Llama, Qwen, DeepSeek, Mistral open-weights; OpenRouter Free com 50 req/dia; Gemini AI Studio free para experimentação; HF créditos mensais pequenos. |
+| Crédito inicial | AI21 US$10/3 meses; Fireworks US$1; Hugging Face US$0,10/mês free ou US$2/mês Pro; Alibaba Model Studio 1M tokens por modelo por 90 dias em International para vários Qwen. |
+| Baixo custo (<US$1/1M efetivo em input e output próximos) | Gemini 2.0 Flash, GPT-4o mini, Command R, Jamba Mini, Llama 4 Scout Groq, Qwen3 32B Groq, Mistral Small 4, DeepSeek Chat/Reasoner, Gemini 2.5 Flash input. |
+| Médio | GPT-4.1, o3, Gemini 2.5 Pro, Codestral, MiniMax M2.5, Kimi K2, GLM-4.5, Llama 3.3 70B, Mistral Large legado. |
+| Premium | Claude Sonnet 4.6, Claude Opus 4.6, o1, Grok 3/4, Command R+, Sonar Pro quando inclui busca. |
+
+## Classificação por especialização
+
+| Especialização | Modelos |
+|---|---|
+| General-purpose | GPT-4o, GPT-4.1, Claude Sonnet/Opus, Gemini, Llama 3.3/4, Mistral Large/Small, Command R, Jamba, Kimi, GLM |
+| Code-specialized | GPT-4.1, Codex, Claude Sonnet/Opus, Codestral, DeepSeek Coder/R1, Qwen-Coder, MiniMax M2.x, Llama 4 Maverick |
+| Reasoning | o3/o3-mini/o1, Claude Opus/Sonnet/Haiku 4.x, Gemini 2.5, DeepSeek R1/Reasoner, QwQ, MiniMax M1, Grok 4, Kimi thinking |
+| Long-context >200K | GPT-4.1, Claude 4.6, Gemini 2.x/2.5, Llama 4 Scout/Maverick, Mistral Small 4, Jamba 1.5, Qwen Plus/Coder long, Kimi K2/K2.5, MiniMax M1/M2.x, Grok 4.20 |
+| Multimodal visão | GPT-4o/4o mini/4.1 input image, Gemini, Llama 4, Mistral Small 4/Large 3, Qwen-VL, Kimi K2.5, Grok 4.20 |
+| Tool-use/Agentic | GPT-4.1/o3/Codex, Claude 4.6, Gemini 2.0/2.5, Command R/R+, Kimi K2, GLM-4.5, MiniMax M2, Qwen-Coder, Grok 4.20 |
+
+## Classificação por proveniência
+
+| Proveniência | Modelos |
+|---|---|
+| Proprietário closed | OpenAI GPT/o/Codex, Anthropic Claude, Google Gemini, xAI Grok, Cohere Command, AI21 API hosted, MiniMax API closed, Mistral Medium/Large premier |
+| Open-weights | Llama, DeepSeek, Qwen, Mistral Small/Large 3/Mixtral, Jamba 1.5, MiniMax M1, Kimi K2, GLM-4.5, Yi |
+| Open-source completo | Poucos. GLM-4.5 declara MIT em fonte pública; vários pesos públicos têm licenças próprias e devem ser tratados como open-weights, não OSI. |
+
+## Classificação por origem geográfica e LGPD
+
+| Origem | Modelos/provedores | Implicação LGPD |
+|---|---|---|
+| EUA | OpenAI, Google, Meta, xAI, Groq, Together, Fireworks, OpenRouter, Replicate, Perplexity | Exigir DPA, retenção zero/baixa, região, subprocessadores; bom ecossistema enterprise. |
+| Europa | Mistral | Melhor narrativa regulatória para clientes sensíveis; ainda confirmar região de inferência. |
+| China | DeepSeek, Alibaba Qwen, MiniMax, Moonshot, Zhipu, 01.AI | Alto cuidado para dados sensíveis, logs de cliente e código proprietário; preferir self-host ou provedor ocidental com política clara. |
+| Outros | Cohere Canadá/EUA, AI21 Israel | Avaliar DPA e região; bons para enterprise/RAG. |
+
+## Classificação por tamanho
+
+| Tamanho | Modelos |
+|---|---|
+| Small <10B | Llama 3.1 8B, Qwen 2.5 7B, Ministral 3B/8B, Gemma/Gemma3n via provedores |
+| Medium 10-70B | Llama 3.3 70B, Qwen 14B/32B/72B, Codestral, Jamba Mini 52B/12B ativo, Qwen3 32B, Mistral 7B/Mixtral active |
+| Large 70-200B | Mistral Small 4 119B/6.5B ativo, Llama 4 Scout 109B/17B ativo, Mixtral 8x22B |
+| Frontier >200B ou closed-frontier | GPT-4o/4.1/o3/o1, Claude 4.6, Gemini 2.5, Llama 3.1 405B, Llama 4 Maverick, DeepSeek 671B, Qwen3 235B, Kimi 1T, MiniMax M1 456B, GLM-4.5 355B, Jamba Large 398B |
+
+## Custo estimado por análise IAC
+
+| Modelo | Custo US$/análise | Custo R$/análise |
+|---|---:|---:|
+| Gemini 2.0 Flash | 0.0016 | 0.0080 |
+| GPT-4o mini | 0.0024 | 0.0120 |
+| Mistral Small 4 | 0.0024 | 0.0120 |
+| Cohere Command R | 0.0024 | 0.0120 |
+| Jamba 1.5 Mini | 0.0024 | 0.0120 |
+| DeepSeek Chat/Reasoner V3.2 | 0.0031 | 0.0154 |
+| Qwen3 32B Groq | 0.0035 | 0.0175 |
+| Codestral | 0.0042 | 0.0210 |
+| MiniMax M2.5 | 0.0048 | 0.0240 |
+| Llama 3.3 70B Groq | 0.0063 | 0.0314 |
+| Gemini 2.5 Flash | 0.0074 | 0.0369 |
+| DeepSeek R1 legado | 0.0088 | 0.0438 |
+| Mistral Large 2.1 | 0.0280 | 0.1397 |
+| Grok 4.20 | 0.0280 | 0.1397 |
+| Gemini 2.5 Pro | 0.0300 | 0.1497 |
+| GPT-4.1 / o3 / Jamba Large | 0.0320 | 0.1597 |
+| GPT-4o / Command R+ | 0.0400 | 0.1996 |
+| Claude Sonnet 4.6 / Grok 3/4 | 0.0540 | 0.2695 |
+| Claude Haiku 4.5 | 0.0180 | 0.0898 |
+| Claude Opus 4.6 | 0.0900 | 0.4491 |
+| o1 | 0.2400 | 1.1977 |
+
+## Custo mensal projetado
+
+| Modelo | 150 issues/mês | 500 issues/mês | 1.500 issues/mês |
+|---|---:|---:|---:|
+| Gemini 2.0 Flash | US$0.24 / R$1,20 | US$0.80 / R$3,99 | US$2,40 / R$11,98 |
+| GPT-4o mini | US$0.36 / R$1,80 | US$1,20 / R$5,99 | US$3,60 / R$17,97 |
+| DeepSeek V3.2 | US$0.46 / R$2,31 | US$1,54 / R$7,69 | US$4,62 / R$23,05 |
+| Gemini 2.5 Flash | US$1,11 / R$5,54 | US$3,70 / R$18,47 | US$11,10 / R$55,39 |
+| GPT-4.1/o3 | US$4,80 / R$23,95 | US$16,00 / R$79,85 | US$48,00 / R$239,54 |
+| Gemini 2.5 Pro | US$4,50 / R$22,46 | US$15,00 / R$74,86 | US$45,00 / R$224,57 |
+| Claude Sonnet 4.6 | US$8,10 / R$40,42 | US$27,00 / R$134,74 | US$81,00 / R$404,23 |
+| Claude Opus 4.6 | US$13,50 / R$67,37 | US$45,00 / R$224,57 | US$135,00 / R$673,72 |
+| o1 | US$36,00 / R$179,66 | US$120,00 / R$598,86 | US$360,00 / R$1.796,58 |
+
+## Gráfico ASCII custo x qualidade
+
+Eixo X: custo por análise em log aproximado. Mais à direita = mais caro. Eixo Y implícito por grupo de qualidade.
+
+```text
+Qualidade 5  DeepSeek R1/V3.2  Gemini2.5Flash      Gemini2.5Pro GPT4.1/o3  Sonnet4.6   Opus4.6
+            |----$0.003----|----$0.007----|--------$0.03--------|--$0.054--|--$0.09--|
+
+Qualidade 4  Qwen3-32B  Codestral MiniMaxM2.5 Llama3.3   MistralSmall4   Grok4.20
+            |--0.0035--|--0.004--|--0.005--|--0.006--|--0.0024--|---0.028---|
+
+Qualidade 3  Gemini2.0Flash GPT4o-mini CommandR JambaMini Mixtral
+            |--0.0016--|--0.0024--|--0.0024--|--0.0024--|---0.006+---|
+```
+
+## Ranking por caso de uso
+
+### Bateria de testes automatizada
+
+1. Ollama local com Qwen2.5-Coder 7B/14B/32B ou Llama 3.1 8B.
+2. OpenRouter Free para testes não determinísticos e baixa frequência.
+3. Gemini 2.0 Flash free/baixo custo quando a bateria precisa de API real.
+
+### Produção volume baixo (<10 issues/dia)
+
+1. Gemini 2.5 Flash.
+2. Claude Haiku 4.5.
+3. GPT-4.1 mini/GPT-4o mini para triagem, com escalation manual.
+
+### Produção volume médio (150 issues/milestone)
+
+1. Gemini 2.5 Flash como primário.
+2. DeepSeek Reasoner/V3.2 como fallback econômico ou modo `loop`.
+3. Claude Sonnet 4.6 para casos com alta severidade.
+
+### Produção volume alto (1000+ issues/mês)
+
+1. Gemini 2.0 Flash ou DeepSeek V3.2 para primeira passada.
+2. Groq Llama 4 Scout/Qwen3 32B para baixa latência.
+3. Escalonamento seletivo para Sonnet 4.6 ou o3 apenas quando heurísticas indicarem baixa confiança.
+
+### Casos críticos
+
+1. Claude Opus 4.6.
+2. Claude Sonnet 4.6.
+3. o3 ou Gemini 2.5 Pro.
+
+### LGPD/dados sensíveis
+
+1. Self-host open-weights: Qwen2.5-Coder/DeepSeek/Llama/Mistral em infraestrutura controlada.
+2. Mistral em região europeia, se contrato e região forem adequados.
+3. OpenAI/Anthropic/Google enterprise com DPA, zero-retention ou data residency contratada.
+
+## Matriz de decisão ponderada
+
+Pesos: custo 30%, qualidade código/stack trace 30%, latência 15%, contexto 10%, maturidade API 10%, compliance 5%. Nota 1-5.
+
+| Modelo | Custo | Código | Latência | Contexto | API | Compliance | Score |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Gemini 2.5 Flash | 5 | 4 | 4 | 5 | 4 | 3 | 4.35 |
+| DeepSeek V3.2/Reasoner | 5 | 4 | 3 | 3 | 4 | 2 | 4.00 |
+| GPT-4o mini | 5 | 3 | 4 | 3 | 5 | 4 | 4.00 |
+| Mistral Small 4 | 5 | 4 | 3 | 4 | 4 | 4 | 4.30 |
+| Claude Sonnet 4.6 | 2 | 5 | 3 | 5 | 5 | 4 | 3.95 |
+| GPT-4.1 | 3 | 5 | 4 | 5 | 5 | 4 | 4.20 |
+| Gemini 2.5 Pro | 3 | 5 | 3 | 5 | 4 | 3 | 3.95 |
+| Groq Llama 4 Scout | 5 | 4 | 5 | 5 | 4 | 3 | 4.50 |
+| Claude Opus 4.6 | 1 | 5 | 2 | 5 | 5 | 4 | 3.35 |
+| o3 | 3 | 5 | 2 | 3 | 5 | 4 | 3.75 |
+
+Resultado: para produção IAC, a decisão pragmática é usar um modelo barato e rápido para 80-90% das análises, com escalonamento para Sonnet/Opus/o3 quando houver baixa confiança, stack trace incompleto, ou impacto alto.
+
+## Estratégia multi-backend recomendada
+
+### Pipeline prático
+
+| Etapa | Primário | Fallback | Critério de escalonamento |
+|---|---|---|---|
+| Extração e normalização | Gemini 2.0 Flash | GPT-4o mini / Command R | Falha em JSON/schema. |
+| Análise técnica padrão | Gemini 2.5 Flash | DeepSeek V3.2 / Qwen3 32B | Confiança baixa, erro ambíguo, contexto >128K. |
+| Reasoning/RCA difícil | Claude Sonnet 4.6 | o3 / Gemini 2.5 Pro | Causa raiz incerta, múltiplos componentes. |
+| Caso crítico | Claude Opus 4.6 | Sonnet 4.6 + o3 cross-check | Incidente P0/P1 ou relatório externo. |
+| Dados sensíveis | Self-host Qwen/DeepSeek/Mistral | Mistral EU / contrato enterprise | Código cliente, logs pessoais, segredo. |
+
+### Políticas de roteamento
+
+- `single`: Gemini 2.0 Flash ou GPT-4o mini para issues simples.
+- `multi`: Gemini 2.5 Flash primário; DeepSeek/Qwen fallback.
+- `loop`: começar barato; a cada iteração usar métrica de confiança e só escalar para Sonnet/o3 se necessário.
+- `premium`: Sonnet 4.6 primeiro; Opus 4.6 apenas para RCA realmente crítico.
+
+## Modelos a evitar no IAC
+
+| Modelo/família | Motivo |
+|---|---|
+| o1 | Custo alto e substituído operacionalmente por o3/o3-mini/GPT-4.1 em muitos fluxos. |
+| Mixtral 8x7B | Contexto e qualidade defasados para stack trace/código moderno. |
+| Llama 3.1 8B / Qwen 7B como produção | Bons para testes, insuficientes para RCA confiável. |
+| Grok 2 | Legado e sem vantagem clara. |
+| abab6.5 | Legado MiniMax; docs atuais priorizam M2.x/M1. |
+| Yi/01.AI API hosted | Menor relevância e preço/limites atuais não verificados. |
+| Perplexity Sonar para logs privados | Produto centrado em web search; não é ideal para código/stack trace sensível. |
+
+## Riscos e caveats
+
+- Preços recentes mudaram em OpenAI, Anthropic, Google, DeepSeek, xAI e Alibaba. Fixar versão de modelo e monitorar pricing semanalmente.
+- Modelos ChatGPT podem ser aposentados sem afetar API; OpenAI afirmou que GPT-4o/4.1 foram aposentados no ChatGPT, não na API.
+- Agregadores podem trocar provedor upstream, quantização ou região; usar pinagem de provider quando reprodutibilidade importar.
+- DeepSeek, Qwen, Kimi, GLM e MiniMax podem ser excelentes tecnicamente, mas exigem avaliação jurídica para LGPD, transferência internacional e segredo de negócio.
+- Reasoning tokens são cobrados como output em vários provedores; prompts `loop` podem custar mais do que a fórmula base.
+- Contexto anunciado não garante qualidade em todo o comprimento. Para IAC, 128K bem usado costuma ser mais valioso que 1M mal recuperado.
+- Free tiers são inadequados para SLA: podem ter filas, coleta de dados, queda de limite e roteamento imprevisível.
+
+## Recomendações finais
+
+### Top 3 dev
+
+1. Ollama + Qwen2.5-Coder 32B ou DeepSeek Coder.
+2. Gemini 2.0 Flash.
+3. OpenRouter Free para smoke tests de API compatível.
+
+### Top 3 bateria
+
+1. Local open-weights.
+2. Gemini 2.0 Flash.
+3. GPT-4o mini ou Command R.
+
+### Top 3 produção
+
+1. Gemini 2.5 Flash.
+2. Mistral Small 4 ou Groq Llama 4 Scout para alternativa open/europeia/rápida.
+3. DeepSeek V3.2/Reasoner para custo mínimo, se compliance permitir.
+
+### Top 3 premium
+
+1. Claude Sonnet 4.6.
+2. Claude Opus 4.6.
+3. o3 ou Gemini 2.5 Pro.
+
+### Recomendação objetiva para o IAC
+
+Implementar OpenAI e Anthropic como backends pendentes, mas não tornar nenhum deles o único caminho de produção. A configuração mais resiliente é:
+
+```yaml
+default_backend: gemini-2.5-flash
+cheap_backend: gemini-2.0-flash
+fast_backend: groq/llama-4-scout
+reasoning_backend: anthropic/claude-sonnet-4.6
+critical_backend: anthropic/claude-opus-4.6
+openai_fallback: openai/gpt-4.1
+local_sensitive_backend: ollama/qwen2.5-coder:32b
+```
+
+## Metodologia e fontes
+
+Coleta realizada por web search em 16/04/2026, priorizando documentação oficial de pricing e model cards. Quando a fonte oficial do criador do modelo não expõe preço API por token, usei provedores de inferência conhecidos e marquei a limitação. Dados de benchmark foram incluídos apenas quando apareceram em páginas oficiais ou descrições de model cards acessadas; caso contrário foram marcados como `⚠️ não verificado`.
+
+Fontes consultadas:
+
+- OpenAI: [API Pricing](https://openai.com/api/pricing/), [platform pricing](https://platform.openai.com/docs/pricing/), [GPT-4.1](https://platform.openai.com/docs/models/gpt-4.1), [GPT-4o](https://platform.openai.com/docs/models/gpt-4o), [GPT-4o mini](https://developers.openai.com/api/docs/models/gpt-4o-mini), [GPT-4.1 release](https://openai.com/index/gpt-4-1/), [rate limits](https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits).
+- Anthropic: [pricing](https://platform.claude.com/docs/en/about-claude/pricing), [Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6), [Sonnet 4.6](https://www.anthropic.com/news/claude-sonnet-4-6), [rate limits](https://docs.anthropic.com/en/api/rate-limits), [model selection](https://claude.com/resources/tutorials/choosing-the-right-claude-model).
+- Google: [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing), [Gemini pricing](https://ai.google.dev/pricing).
+- Meta/Llama: [Llama 3.1 HF](https://huggingface.co/meta-llama/Llama-3.1-405B), [Llama 3.3 NVIDIA](https://build.nvidia.com/meta/llama-3_3-70b-instruct/modelcard), [Llama 4 docs](https://huggingface.co/docs/transformers/en/model_doc/llama4), [Llama 4 Scout](https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E), [Llama 4 Maverick](https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E).
+- Mistral: [models](https://docs.mistral.ai/getting-started/models), [Mistral Small 4](https://docs.mistral.ai/models/mistral-small-4-0-26-03), [Codestral](https://docs.mistral.ai/models/codestral-25-08).
+- DeepSeek: [pricing](https://api-docs.deepseek.com/quick_start/pricing/), [pricing details](https://api-docs.deepseek.com/quick_start/pricing-details-usd/), [overview](https://api-docs.deepseek.com/), [reasoner](https://api-docs.deepseek.com/guides/reasoning_model).
+- Alibaba/Qwen: [Model Studio pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing), [billing](https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio).
+- MiniMax: [API overview](https://platform.minimax.io/docs/api-reference/api-overview), [text generation](https://platform.minimax.io/docs/guides/text-generation), [M1 announcement](https://www.minimax.io/news/minimaxm1), [M1 GitHub](https://github.com/MiniMax-AI/MiniMax-M1).
+- xAI: [API page](https://x.ai/api), [models/pricing](https://docs.x.ai/docs/models), [rate limits](https://docs.x.ai/developers/rate-limits), [consumption](https://docs.x.ai/docs/key-information/consumption-and-rate-limits).
+- Cohere: [Command R+](https://docs.cohere.com/v2/docs/command-r-plus), [Command R](https://docs.cohere.com/docs/command-r), [pricing](https://cohere.com/pricing).
+- AI21: [pricing](https://www.ai21.com/pricing/), [Jamba research](https://www.ai21.com/research/jamba-1-5-hybrid-transformer-mamba-models-at-scale/), [AWS Jamba Large](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-ai21-labs-jamba-1-5-large.html).
+- Multi-modelo: [Groq pricing](https://groq.com/pricing), [Together pricing](https://www.together.ai/pricing), [Fireworks pricing](https://fireworks.ai/pricing), [OpenRouter pricing](https://openrouter.ai/pricing), [OpenRouter rate limits](https://openrouter.zendesk.com/hc/en-us/articles/39501163636379-OpenRouter-Rate-Limits-What-You-Need-to-Know), [OpenRouter Free](https://openrouter.ai/openrouter/free), [Hugging Face pricing](https://huggingface.co/docs/api-inference/en/pricing), [Replicate pricing](https://replicate.com/pricing), [Perplexity pricing](https://docs.perplexity.ai/docs/getting-started/pricing).
+- Chineses adicionais: [Kimi pricing](https://platform.moonshot.ai/docs/pricing/chat), [Kimi overview](https://platform.moonshot.ai/docs/overview), [GLM-4.5 public page](https://glm45.org/), [GLM pricing aggregator](https://lmmarketcap.com/pricing-page/model/z-ai-glm-4-5).
+- Câmbio: [Investing.com USD/BRL](https://www.investing.com/currencies/usd-brl-historical-data).

--- a/docs/catalogo-llms-2026-codex.md
+++ b/docs/catalogo-llms-2026-codex.md
@@ -25,61 +25,186 @@ custo_BRL = custo_USD * 4,9905
 
 ## Tabela mestre
 
-Legenda de qualidade: ★ fraco, ★★ aceitável, ★★★ bom, ★★★★ muito bom, ★★★★★ frontier.  
+Legenda de qualidade: ★ fraco, ★★ aceitável, ★★★ bom, ★★★★ muito bom, ★★★★★ frontier.
+Preço I/O em USD por 1M tokens. Informações complementares (arquitetura, API, observações) logo abaixo de cada sub-tabela.
 API: `OA` = OpenAI-compatible, `Nativa` = SDK/API própria.
 
-| Modelo | Provedor/API | Origem | Tipo | Contexto | Tamanho/arquitetura | Input | Output | IAC US$ | Qual. IAC | API | Observações |
-|---|---|---:|---|---:|---|---:|---:|---:|---:|---|---|
-| GPT-4o | OpenAI | EUA | proprietário, multimodal | 128K | closed/dense? | 2.50 | 10.00 | 0.0400 | ★★★★ | Nativa/OA | Legado útil; API mantida, ChatGPT aposentou. |
-| GPT-4o mini | OpenAI | EUA | proprietário, baixo custo | 128K | closed | 0.15 | 0.60 | 0.0024 | ★★★ | Nativa/OA | Excelente triagem barata. |
-| GPT-4.1 | OpenAI | EUA | proprietário, código | 1.05M | closed | 2.00 | 8.00 | 0.0320 | ★★★★ | Nativa/OA | Forte em código; SWE-bench Verified 54,6% divulgado. |
-| o3 | OpenAI | EUA | proprietário, reasoning | ⚠️ não verificado | closed | 2.00 | 8.00 | 0.0320 | ★★★★★ | Nativa/OA | Melhor quando há análise causal difícil. |
-| o3-mini | OpenAI | EUA | proprietário, reasoning barato | ⚠️ não verificado | closed | 1.10 | 4.40 | 0.0176 | ★★★★ | Nativa/OA | Boa opção de fallback reasoning. |
-| o1 | OpenAI | EUA | proprietário, reasoning premium legado | ⚠️ não verificado | closed | 15.00 | 60.00 | 0.2400 | ★★★★ | Nativa/OA | Caro; evitar salvo compatibilidade antiga. |
-| Codex mini / GPT Codex | OpenAI | EUA | code-specialized | 256K-? | closed | 1.50 | 6.00 | 0.0240 | ★★★★ | Nativa/OA | Para edição/agentes de código; há variantes GPT-5.1 Codex mini mais baratas. |
-| Claude Opus 4.6 | Anthropic | EUA | proprietário, reasoning/código | 1M beta | closed | 5.00 | 25.00 | 0.0900 | ★★★★★ | Nativa | Premium; melhor para issues críticas. |
-| Claude Sonnet 4.6 | Anthropic | EUA | proprietário, coding/agentic | 1M beta | closed | 3.00 | 15.00 | 0.0540 | ★★★★★ | Nativa | Melhor default premium para IAC. |
-| Claude Haiku 4.5 | Anthropic | EUA | proprietário, rápido | ⚠️ não verificado | closed | 1.00 | 5.00 | 0.0180 | ★★★★ | Nativa | Boa triagem com qualidade acima do preço. |
-| Gemini 2.5 Pro | Google | EUA | proprietário, multimodal/reasoning | 1M | closed | 1.25 | 10.00 | 0.0300 | ★★★★★ | Nativa/OA parcial | Ótimo long-context; output caro. |
-| Gemini 2.5 Flash | Google | EUA | proprietário, baixo custo/reasoning | 1M | closed | 0.30 | 2.50 | 0.0074 | ★★★★ | Nativa/OA parcial | Melhor custo-benefício geral. |
-| Gemini 2.0 Flash | Google | EUA | proprietário, multimodal barato | 1M | closed | 0.10 | 0.40 | 0.0016 | ★★★ | Nativa/OA parcial | Fortíssimo para volume e testes pagos. |
-| Llama 3.3 70B | Meta via Groq/Together | EUA | open-weights | 128K | 70B dense | 0.59-0.88 | 0.79-0.88 | 0.0063-0.0088 | ★★★ | OA via provedor | Boa alternativa barata; menos forte que Sonnet/GPT em RCA complexo. |
-| Llama 3.1 405B | Meta via provedores | EUA | open-weights | 128K | 405B dense | variável | variável | ⚠️ | ★★★★ | OA via provedor | Peso público; caro de hospedar. |
-| Llama 3.1 70B | Meta via provedores | EUA | open-weights | 128K | 70B dense | variável | variável | ⚠️ | ★★★ | OA via provedor | Superado por 3.3 70B na maioria dos usos. |
-| Llama 3.1 8B | Meta via Groq/local | EUA | open-weights, small | 128K | 8B dense | 0.05 | 0.08 | 0.0006 | ★★ | OA/local | Bom para testes, ruim para análise causal profunda. |
-| Llama 4 Scout | Meta via Groq/Together | EUA | open-weights, multimodal | 10M | MoE 109B total/17B ativo | 0.11 | 0.34 | 0.0016 | ★★★★ | OA via provedor | Muito interessante para contexto enorme. |
-| Llama 4 Maverick | Meta via provedores | EUA | open-weights, multimodal | 1M | MoE ~400B/17B ativo | variável | variável | ⚠️ | ★★★★ | OA via provedor | Mais forte que Scout; disponibilidade/preço variam. |
-| Mistral Large 2.1 | Mistral | Europa | proprietário legado | 128K | closed | 2.00 | 6.00 | 0.0280 | ★★★★ | Nativa/OA | Legado; Large 3 é open-weight mais novo. |
-| Mistral Medium 3.1 | Mistral | Europa | proprietário | ⚠️ | closed | ⚠️ | ⚠️ | ⚠️ | ★★★★ | Nativa/OA | Preço oficial não verificado no crawl; modelo recomendado pela Mistral. |
-| Mistral Small 4 | Mistral | Europa | open-weights, hybrid | 256K | MoE 119B/6.5B ativo | 0.15 | 0.60 | 0.0024 | ★★★★ | Nativa/OA | Forte opção europeia e barata. |
-| Mixtral 8x7B | Mistral/Together | Europa | open-weights | 32K | MoE ~47B/13B ativo | 0.60 | 0.60 | 0.0060 | ★★ | OA via provedor | Legado; evitar para IAC moderno. |
-| Mixtral 8x22B | Mistral/Fireworks | Europa | open-weights | 64K | MoE ~141B/39B ativo | ~1.20 | ~1.20 | 0.0120 | ★★★ | OA via provedor | Ainda útil, mas superado por Small 4/DeepSeek. |
-| Codestral 25.08 | Mistral | Europa | code-specialized | 128K | closed/premier | 0.30 | 0.90 | 0.0042 | ★★★★ | Nativa/OA | Bom para FIM/código; não é melhor RCA geral. |
-| DeepSeek V3/V3.1 | DeepSeek/provedores | China | open-weights | 64K-128K | MoE 671B/37B ativo | 0.28-0.60 | 0.42-1.70 | 0.0031-0.0082 | ★★★★ | OA | Excelente custo/qualidade; cautela LGPD. |
-| DeepSeek Coder | DeepSeek/provedores | China | open-weights, código | variável | variável | ⚠️ | ⚠️ | ⚠️ | ★★★★ | OA/local | Bom local; preço oficial atual não verificado. |
-| DeepSeek Reasoner/R1 | DeepSeek | China | open-weights/reasoning | 128K | MoE | 0.28-0.55 | 0.42-2.19 | 0.0031-0.0088 | ★★★★★ | OA | Muito bom em custo; output reasoning pode inflar. |
-| Qwen 2.5 72B | Alibaba/provedores | China | open-weights | 128K | 72B dense | variável | variável | ⚠️ | ★★★★ | OA/local | Bom para código e pt-BR; preço depende do host. |
-| Qwen 2.5 32B | Alibaba/provedores | China | open-weights | 128K | 32B dense | variável | variável | ⚠️ | ★★★ | OA/local | Ótimo local/baixo custo. |
-| Qwen 2.5 14B | Alibaba/provedores | China | open-weights | 128K | 14B dense | variável | variável | ⚠️ | ★★ | OA/local | Testes e dev local. |
-| Qwen 2.5 7B | Alibaba/provedores | China | open-weights | 128K | 7B dense | 0.30 Together | 0.30 | 0.0030 | ★★ | OA/local | Apenas triagem simples. |
-| Qwen3 32B | Groq/Alibaba/provedores | China | open-weights/reasoning | 131K | 32B dense | 0.29 Groq | 0.59 | 0.0035 | ★★★★ | OA via provedor | Bom custo e latência no Groq. |
-| Qwen3 235B | Alibaba/provedores | China | open-weights/MoE | 128K+ | MoE 235B/A22B | variável | variável | ⚠️ | ★★★★ | OA | Forte; preço oficial por variante DashScope é confuso. |
-| Qwen-Coder | Alibaba | China | code-specialized | até 1M em qwen3-coder | MoE/dense por versão | 1.00+ | 5.00+ | 0.0180+ | ★★★★ | OA | Caro em janelas longas; bom em agentic coding. |
-| QwQ | Alibaba/provedores | China | reasoning | 32K-128K | 32B | variável | variável | ⚠️ | ★★★ | OA/local | Superado por Qwen3 reasoning/DeepSeek R1. |
-| MiniMax abab6.5 | MiniMax | China | proprietário legado | ⚠️ | closed | ⚠️ | ⚠️ | ⚠️ | ★★★ | OA parcial | Legado; docs atuais priorizam M2.x. |
-| MiniMax M1 | MiniMax | China | open-weight reasoning | 1M | MoE 456B/45.9B ativo | 0.40* | 2.20* | 0.0076 | ★★★★ | OA/Anthropic compat | *Preço não oficial direto; pesos e specs oficiais. |
-| MiniMax M2.5 | MiniMax | China | proprietário, código/agentic | 204.8K | closed | 0.30 Fireworks/Together | 1.20 | 0.0048 | ★★★★ | OA/Anthropic compat | Docs oficiais confirmam 60-100 tps. |
-| Grok 2 | xAI | EUA | proprietário legado | ⚠️ | closed | ⚠️ | ⚠️ | ⚠️ | ★★★ | OA | Substituído por Grok 3/4. |
-| Grok 3 | xAI | EUA | proprietário | 131K | closed | 3.00 | 15.00 | 0.0540 | ★★★★ | OA | Mesmo preço de Sonnet; menos atraente para IAC. |
-| Grok 4 | xAI | EUA | proprietário reasoning | 256K | closed | 3.00 | 15.00 | 0.0540 | ★★★★ | OA | Bom, mas Grok 4.20/4.1 Fast já mudaram o cenário. |
-| Grok 4.20 | xAI | EUA | proprietário agentic | 2M | closed | 2.00 | 6.00 | 0.0280 | ★★★★ | OA | Atual flagship listado pela xAI; incluir como sucessor prático. |
-| Cohere Command R+ | Cohere | Canadá/EUA | proprietário RAG/tool | 128K | closed | 2.50 | 10.00 | 0.0400 | ★★★ | Nativa | Forte em RAG/citações; caro frente a Flash. |
-| Cohere Command R | Cohere | Canadá/EUA | proprietário RAG barato | 128K | closed | 0.15 | 0.60 | 0.0024 | ★★★ | Nativa | Bom para extração e RAG simples. |
-| AI21 Jamba 1.5 Large | AI21 | Israel | open-weights | 256K | hybrid SSM-Transformer MoE 398B/94B | 2.00 | 8.00 | 0.0320 | ★★★ | Nativa/Bedrock | Long-context bom; ecossistema menor. |
-| AI21 Jamba 1.5 Mini | AI21 | Israel | open-weights | 256K | hybrid MoE 52B/12B | 0.20 | 0.40 | 0.0024 | ★★★ | Nativa/Bedrock | Barato, bom para documentos longos simples. |
-| Zhipu GLM-4/4.5 | Zhipu | China | open/proprietário por versão | 128K | GLM-4.5 MoE 355B/32B | 0.60* | 2.20* | 0.0092 | ★★★★ | OA | *Preço de agregador; confirmar no console oficial. |
-| Moonshot Kimi K2 | Moonshot | China | open-weights/MoE | 128K-256K | 1T/32B ativo | 0.15-0.60 | 2.00-2.50 | 0.0062 | ★★★★ | OA/Anthropic compat | Bom para agentes/código; origem China. |
-| 01.AI Yi | 01.AI | China | open-weights | 32K-200K | 6B-34B+ | ⚠️ | ⚠️ | ⚠️ | ★★ | OA via host | Menos relevante em 2026; evitar salvo legado/local. |
+### OpenAI (EUA)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| GPT-4o | multimodal | 128K | 2.50 / 10.00 | 0.0400 | ★★★★ |
+| GPT-4o mini | baixo custo | 128K | 0.15 / 0.60 | 0.0024 | ★★★ |
+| GPT-4.1 | código | 1.05M | 2.00 / 8.00 | 0.0320 | ★★★★ |
+| o3 | reasoning | ⚠️ | 2.00 / 8.00 | 0.0320 | ★★★★★ |
+| o3-mini | reasoning barato | ⚠️ | 1.10 / 4.40 | 0.0176 | ★★★★ |
+| o1 | reasoning legado | ⚠️ | 15.00 / 60.00 | 0.2400 | ★★★★ |
+| Codex mini / GPT Codex | code-specialized | 256K-? | 1.50 / 6.00 | 0.0240 | ★★★★ |
+
+**Complementares:**
+- **GPT-4o** — closed/dense · API Nativa/OA · Legado útil; API mantida, ChatGPT aposentou.
+- **GPT-4o mini** — closed · API Nativa/OA · Excelente triagem barata.
+- **GPT-4.1** — closed · API Nativa/OA · Forte em código; SWE-bench Verified 54,6% divulgado.
+- **o3** — closed · API Nativa/OA · Melhor quando há análise causal difícil.
+- **o3-mini** — closed · API Nativa/OA · Boa opção de fallback reasoning.
+- **o1** — closed · API Nativa/OA · Caro; evitar salvo compatibilidade antiga.
+- **Codex mini / GPT Codex** — closed · API Nativa/OA · Para edição/agentes de código; há variantes GPT-5.1 Codex mini mais baratas.
+
+### Anthropic (EUA)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| Claude Opus 4.6 | reasoning/código | 1M beta | 5.00 / 25.00 | 0.0900 | ★★★★★ |
+| Claude Sonnet 4.6 | coding/agentic | 1M beta | 3.00 / 15.00 | 0.0540 | ★★★★★ |
+| Claude Haiku 4.5 | rápido | ⚠️ | 1.00 / 5.00 | 0.0180 | ★★★★ |
+
+**Complementares:**
+- **Claude Opus 4.6** — closed · API Nativa · Premium; melhor para issues críticas.
+- **Claude Sonnet 4.6** — closed · API Nativa · Melhor default premium para IAC.
+- **Claude Haiku 4.5** — closed · API Nativa · Boa triagem com qualidade acima do preço.
+
+### Google Gemini (EUA)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| Gemini 2.5 Pro | multimodal/reasoning | 1M | 1.25 / 10.00 | 0.0300 | ★★★★★ |
+| Gemini 2.5 Flash | baixo custo/reasoning | 1M | 0.30 / 2.50 | 0.0074 | ★★★★ |
+| Gemini 2.0 Flash | multimodal barato | 1M | 0.10 / 0.40 | 0.0016 | ★★★ |
+
+**Complementares:**
+- **Gemini 2.5 Pro** — closed · API Nativa/OA parcial · Ótimo long-context; output caro.
+- **Gemini 2.5 Flash** — closed · API Nativa/OA parcial · Melhor custo-benefício geral.
+- **Gemini 2.0 Flash** — closed · API Nativa/OA parcial · Fortíssimo para volume e testes pagos.
+
+### Meta Llama (EUA)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| Llama 3.3 70B | open-weights | 128K | 0.59-0.88 / 0.79-0.88 | 0.0063-0.0088 | ★★★ |
+| Llama 3.1 405B | open-weights | 128K | variável | ⚠️ | ★★★★ |
+| Llama 3.1 70B | open-weights | 128K | variável | ⚠️ | ★★★ |
+| Llama 3.1 8B | open-weights small | 128K | 0.05 / 0.08 | 0.0006 | ★★ |
+| Llama 4 Scout | open-weights multimodal | 10M | 0.11 / 0.34 | 0.0016 | ★★★★ |
+| Llama 4 Maverick | open-weights multimodal | 1M | variável | ⚠️ | ★★★★ |
+
+**Complementares:**
+- **Llama 3.3 70B** — 70B dense · Meta via Groq/Together · API OA via provedor · Boa alternativa barata; menos forte que Sonnet/GPT em RCA complexo.
+- **Llama 3.1 405B** — 405B dense · Meta via provedores · API OA via provedor · Peso público; caro de hospedar.
+- **Llama 3.1 70B** — 70B dense · Meta via provedores · API OA via provedor · Superado por 3.3 70B na maioria dos usos.
+- **Llama 3.1 8B** — 8B dense · Meta via Groq/local · API OA/local · Bom para testes, ruim para análise causal profunda.
+- **Llama 4 Scout** — MoE 109B total/17B ativo · Meta via Groq/Together · API OA via provedor · Muito interessante para contexto enorme.
+- **Llama 4 Maverick** — MoE ~400B/17B ativo · Meta via provedores · API OA via provedor · Mais forte que Scout; disponibilidade/preço variam.
+
+### Mistral AI (Europa)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| Mistral Large 2.1 | proprietário legado | 128K | 2.00 / 6.00 | 0.0280 | ★★★★ |
+| Mistral Medium 3.1 | proprietário | ⚠️ | ⚠️ / ⚠️ | ⚠️ | ★★★★ |
+| Mistral Small 4 | open-weights hybrid | 256K | 0.15 / 0.60 | 0.0024 | ★★★★ |
+| Mixtral 8x7B | open-weights | 32K | 0.60 / 0.60 | 0.0060 | ★★ |
+| Mixtral 8x22B | open-weights | 64K | ~1.20 / ~1.20 | 0.0120 | ★★★ |
+| Codestral 25.08 | code-specialized | 128K | 0.30 / 0.90 | 0.0042 | ★★★★ |
+
+**Complementares:**
+- **Mistral Large 2.1** — closed · API Nativa/OA · Legado; Large 3 é open-weight mais novo.
+- **Mistral Medium 3.1** — closed · API Nativa/OA · Preço oficial não verificado no crawl; modelo recomendado pela Mistral.
+- **Mistral Small 4** — MoE 119B/6.5B ativo · API Nativa/OA · Forte opção europeia e barata.
+- **Mixtral 8x7B** — MoE ~47B/13B ativo · Mistral/Together · API OA via provedor · Legado; evitar para IAC moderno.
+- **Mixtral 8x22B** — MoE ~141B/39B ativo · Mistral/Fireworks · API OA via provedor · Ainda útil, mas superado por Small 4/DeepSeek.
+- **Codestral 25.08** — closed/premier · API Nativa/OA · Bom para FIM/código; não é melhor RCA geral.
+
+### DeepSeek (China)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| DeepSeek V3/V3.1 | open-weights | 64K-128K | 0.28-0.60 / 0.42-1.70 | 0.0031-0.0082 | ★★★★ |
+| DeepSeek Coder | open-weights código | variável | ⚠️ / ⚠️ | ⚠️ | ★★★★ |
+| DeepSeek Reasoner/R1 | open-weights reasoning | 128K | 0.28-0.55 / 0.42-2.19 | 0.0031-0.0088 | ★★★★★ |
+
+**Complementares:**
+- **DeepSeek V3/V3.1** — MoE 671B/37B ativo · DeepSeek/provedores · API OA · Excelente custo/qualidade; cautela LGPD.
+- **DeepSeek Coder** — variável · DeepSeek/provedores · API OA/local · Bom local; preço oficial atual não verificado.
+- **DeepSeek Reasoner/R1** — MoE · API OA · Muito bom em custo; output reasoning pode inflar.
+
+### Alibaba Qwen (China)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| Qwen 2.5 72B | open-weights | 128K | variável | ⚠️ | ★★★★ |
+| Qwen 2.5 32B | open-weights | 128K | variável | ⚠️ | ★★★ |
+| Qwen 2.5 14B | open-weights | 128K | variável | ⚠️ | ★★ |
+| Qwen 2.5 7B | open-weights | 128K | 0.30 / 0.30 (Together) | 0.0030 | ★★ |
+| Qwen3 32B | open-weights reasoning | 131K | 0.29 / 0.59 (Groq) | 0.0035 | ★★★★ |
+| Qwen3 235B | open-weights/MoE | 128K+ | variável | ⚠️ | ★★★★ |
+| Qwen-Coder | code-specialized | até 1M em qwen3-coder | 1.00+ / 5.00+ | 0.0180+ | ★★★★ |
+| QwQ | reasoning | 32K-128K | variável | ⚠️ | ★★★ |
+
+**Complementares:**
+- **Qwen 2.5 72B** — 72B dense · Alibaba/provedores · API OA/local · Bom para código e pt-BR; preço depende do host.
+- **Qwen 2.5 32B** — 32B dense · Alibaba/provedores · API OA/local · Ótimo local/baixo custo.
+- **Qwen 2.5 14B** — 14B dense · Alibaba/provedores · API OA/local · Testes e dev local.
+- **Qwen 2.5 7B** — 7B dense · Alibaba/provedores · API OA/local · Apenas triagem simples.
+- **Qwen3 32B** — 32B dense · Groq/Alibaba/provedores · API OA via provedor · Bom custo e latência no Groq.
+- **Qwen3 235B** — MoE 235B/A22B · Alibaba/provedores · API OA · Forte; preço oficial por variante DashScope é confuso.
+- **Qwen-Coder** — MoE/dense por versão · Alibaba · API OA · Caro em janelas longas; bom em agentic coding.
+- **QwQ** — 32B · Alibaba/provedores · API OA/local · Superado por Qwen3 reasoning/DeepSeek R1.
+
+### MiniMax (China)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| MiniMax abab6.5 | proprietário legado | ⚠️ | ⚠️ / ⚠️ | ⚠️ | ★★★ |
+| MiniMax M1 | open-weight reasoning | 1M | 0.40* / 2.20* | 0.0076 | ★★★★ |
+| MiniMax M2.5 | proprietário código/agentic | 204.8K | 0.30 / 1.20 (Fireworks/Together) | 0.0048 | ★★★★ |
+
+**Complementares:**
+- **MiniMax abab6.5** — closed · API OA parcial · Legado; docs atuais priorizam M2.x.
+- **MiniMax M1** — MoE 456B/45.9B ativo · API OA/Anthropic compat · *Preço não oficial direto; pesos e specs oficiais.
+- **MiniMax M2.5** — closed · API OA/Anthropic compat · Docs oficiais confirmam 60-100 tps.
+
+### xAI (EUA)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| Grok 2 | proprietário legado | ⚠️ | ⚠️ / ⚠️ | ⚠️ | ★★★ |
+| Grok 3 | proprietário | 131K | 3.00 / 15.00 | 0.0540 | ★★★★ |
+| Grok 4 | proprietário reasoning | 256K | 3.00 / 15.00 | 0.0540 | ★★★★ |
+| Grok 4.20 | proprietário agentic | 2M | 2.00 / 6.00 | 0.0280 | ★★★★ |
+
+**Complementares:**
+- **Grok 2** — closed · API OA · Substituído por Grok 3/4.
+- **Grok 3** — closed · API OA · Mesmo preço de Sonnet; menos atraente para IAC.
+- **Grok 4** — closed · API OA · Bom, mas Grok 4.20/4.1 Fast já mudaram o cenário.
+- **Grok 4.20** — closed · API OA · Atual flagship listado pela xAI; incluir como sucessor prático.
+
+### Cohere e AI21
+
+| Modelo | Origem | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---|---:|---:|---:|---:|
+| Cohere Command R+ | Canadá/EUA | RAG/tool | 128K | 2.50 / 10.00 | 0.0400 | ★★★ |
+| Cohere Command R | Canadá/EUA | RAG barato | 128K | 0.15 / 0.60 | 0.0024 | ★★★ |
+| AI21 Jamba 1.5 Large | Israel | open-weights long-context | 256K | 2.00 / 8.00 | 0.0320 | ★★★ |
+| AI21 Jamba 1.5 Mini | Israel | open-weights | 256K | 0.20 / 0.40 | 0.0024 | ★★★ |
+
+**Complementares:**
+- **Cohere Command R+** — closed · API Nativa · Forte em RAG/citações; caro frente a Flash.
+- **Cohere Command R** — closed · API Nativa · Bom para extração e RAG simples.
+- **AI21 Jamba 1.5 Large** — hybrid SSM-Transformer MoE 398B/94B · API Nativa/Bedrock · Long-context bom; ecossistema menor.
+- **AI21 Jamba 1.5 Mini** — hybrid MoE 52B/12B · API Nativa/Bedrock · Barato, bom para documentos longos simples.
+
+### Chineses adicionais (China)
+
+| Modelo | Perfil | Contexto | Preço I/O | IAC US$ | Qual. |
+|---|---|---:|---:|---:|---:|
+| Zhipu GLM-4/4.5 | open/proprietário por versão | 128K | 0.60* / 2.20* | 0.0092 | ★★★★ |
+| Moonshot Kimi K2 | open-weights/MoE | 128K-256K | 0.15-0.60 / 2.00-2.50 | 0.0062 | ★★★★ |
+| 01.AI Yi | open-weights | 32K-200K | ⚠️ / ⚠️ | ⚠️ | ★★ |
+
+**Complementares:**
+- **Zhipu GLM-4/4.5** — GLM-4.5 MoE 355B/32B · API OA · *Preço de agregador; confirmar no console oficial.
+- **Moonshot Kimi K2** — 1T/32B ativo · API OA/Anthropic compat · Bom para agentes/código; origem China.
+- **01.AI Yi** — 6B-34B+ · API OA via host · Menos relevante em 2026; evitar salvo legado/local.
 
 Fontes principais do bloco: OpenAI pricing/model docs, Anthropic pricing/news/rate-limit docs, Google Gemini pricing, Groq pricing, Together pricing, Fireworks pricing, DeepSeek docs, Mistral docs, Cohere docs, AI21 pricing/research, xAI docs/API page, Alibaba Model Studio pricing, MiniMax docs/news, Meta/Hugging Face model cards, OpenRouter pricing/rate limits, Hugging Face pricing, Replicate pricing, Perplexity pricing.
 

--- a/docs/prompt-catalogo-llms-2026.md
+++ b/docs/prompt-catalogo-llms-2026.md
@@ -1,0 +1,100 @@
+# Prompt — Catálogo comparativo de LLMs via API (2026)
+
+> Uso: rode este prompt em um LLM com **web search habilitado** (Claude Code com `WebSearch`, Codex com `--search`, ChatGPT/Perplexity/Gemini web).
+> Comando sugerido:
+> ```bash
+> claude -p "$(cat docs/prompt-catalogo-llms-2026.md)" \
+>   --allowed-tools "WebSearch,WebFetch" \
+>   > docs/catalogo-llms-2026.md
+> ```
+
+---
+
+Você é um analista técnico especializado em LLMs. Produza um **relatório em Markdown** (pt-BR) com análise profunda e comparativa de todas as LLMs relevantes disponíveis via API em 2026, cobrindo opções gratuitas, de baixo custo e premium.
+
+## Contexto do projeto (IAC — Incident Analyst Agent)
+
+- Ferramenta CLI que analisa issues do GitLab/GitHub (stack traces, logs, código Django/Python) e gera relatórios técnicos.
+- Consumo típico: **3–6 requests por issue**, **~10K tokens por análise** (input majoritariamente código + stack trace; output estruturado em Markdown).
+- Volume alvo: **~150 issues por milestone**, ~4 milestones/ano.
+- Modos de uso: `single` (2 req), `multi` (3–4 req), `loop` (4–6 req).
+- Hoje integrados: Ollama (local), Groq, DeepSeek, Gemini. Pendentes: OpenAI, Anthropic.
+
+## Escopo obrigatório
+
+Inclua **no mínimo** estes provedores/famílias (não omita nenhum):
+
+- **OpenAI:** GPT-4o, GPT-4o mini, GPT-4.1, o3, o3-mini, o1, Codex
+- **Anthropic:** Claude Opus 4.6, Sonnet 4.6, Haiku 4.5
+- **Google:** Gemini 2.5 Pro, 2.5 Flash, 2.0 Flash
+- **Meta:** Llama 3.3 70B, Llama 3.1 (405B/70B/8B), Llama 4 (Scout/Maverick)
+- **Mistral AI:** Mistral Large, Medium, Small, Mixtral 8x7B, 8x22B, Codestral
+- **DeepSeek:** V3, V3.1, Coder, Reasoner (R1)
+- **Alibaba Qwen:** Qwen 2.5 (72B/32B/14B/7B), Qwen3 (32B/235B), Qwen-Coder, QwQ
+- **MiniMax:** abab6.5, M1 (reasoning)
+- **xAI:** Grok 2, Grok 3, Grok 4 (se lançado)
+- **Cohere:** Command R+, Command R
+- **AI21:** Jamba 1.5 Large/Mini
+- **Provedores de inferência multi-modelo:** Groq, Together.ai, Fireworks, OpenRouter, HuggingFace Inference, Replicate, Perplexity API
+- **Chineses adicionais:** Zhipu (GLM-4), Moonshot (Kimi), 01.AI (Yi)
+
+## Categorias de classificação
+
+Organize os modelos em **todas** estas dimensões (um modelo pode aparecer em várias):
+
+1. **Por faixa de custo:** Gratuito permanente · Crédito inicial · Baixo custo (<$1/1M tokens) · Médio · Premium
+2. **Por especialização:** General-purpose · Code-specialized · Reasoning · Long-context (>200K) · Multimodal (visão) · Tool-use/Agentic
+3. **Por proveniência:** Proprietário (closed) · Open-weights (pesos públicos) · Open-source completo
+4. **Por origem geográfica:** EUA · Europa · China · Outros (contexto regulatório/LGPD)
+5. **Por tamanho:** Small (<10B) · Medium (10–70B) · Large (70–200B) · Frontier (>200B ou closed-frontier)
+
+## Dados obrigatórios por modelo
+
+Para cada modelo, apresente:
+
+- Nome e provedor
+- Data de lançamento / última atualização
+- **Preço input / output por 1M tokens** (USD, valores oficiais atuais — **cite a fonte com link** ao final da seção)
+- **Limites do tier gratuito** (req/min, req/dia, crédito inicial)
+- **Context window** (tokens)
+- **Tamanho** (parâmetros, se público) e **arquitetura** (dense/MoE)
+- **Latência típica** observada (tokens/s ou s por resposta de 1K tokens)
+- **Qualidade** (★ de 1 a 5) em: raciocínio geral, código, instrução, long-context
+- Pontuações em benchmarks relevantes (MMLU, HumanEval, SWE-bench, LMSys Arena) quando disponíveis
+- **Forças e fraquezas** em 1–2 linhas cada
+- Compatibilidade de API (OpenAI-compatible? nativa?)
+
+## Análise comparativa obrigatória
+
+Inclua estas seções/tabelas:
+
+1. **Tabela mestre** com todas as LLMs listadas, ordenável por custo e qualidade.
+2. **Custo estimado por análise IAC** (~10K tokens, ratio input/output 4:1) em USD e BRL.
+3. **Custo mensal projetado** para 150, 500 e 1.500 issues/mês.
+4. **Gráfico ASCII custo × qualidade** (log scale no custo).
+5. **Ranking por caso de uso:**
+   - Bateria de testes automatizada (volume, sem custo)
+   - Produção volume baixo (<10 issues/dia)
+   - Produção volume médio (150 issues/milestone)
+   - Produção volume alto (1000+ issues/mês)
+   - Casos críticos (máxima qualidade, custo não importa)
+   - Ambiente com LGPD/dados sensíveis (on-premise ou região específica)
+6. **Matriz de decisão** com pesos: custo (30%), qualidade código/stack trace (30%), latência (15%), context window (10%), maturidade API (10%), compliance (5%).
+7. **Riscos e caveats:** mudanças de preço recentes, modelos deprecated, provedores instáveis, restrições geográficas/LGPD.
+
+## Recomendações finais
+
+- Top 3 para cada caso de uso (dev, bateria, produção, premium).
+- Estratégia **multi-backend** (qual modelo usar como primário e qual como fallback).
+- Modelos a **evitar** no contexto IAC e por quê.
+
+## Requisitos de formato
+
+- Markdown puro, sem HTML.
+- Cabeçalhos hierárquicos (`#`, `##`, `###`).
+- Tabelas compactas, colunas alinhadas.
+- Todos os preços e limites com **link para a fonte oficial** ao final de cada bloco.
+- Ao final, uma seção **"Metodologia e fontes"** listando como os dados foram coletados e a data de referência.
+- Se algum dado não for verificável, marque explicitamente com `⚠️ não verificado` em vez de inventar.
+
+Produza o relatório completo agora.

--- a/scripts/run_battery.sh
+++ b/scripts/run_battery.sh
@@ -15,7 +15,7 @@
 #   - .iac/.env configurado (GITLAB_TOKEN, IAC_LLM_BACKEND, API key)
 #   - iac instalado (pip install -e .)
 
-set -euo pipefail
+set -uo pipefail
 
 # ---------------------------------------------------------------------------
 # Argumentos
@@ -125,21 +125,29 @@ for MODEL in "${MODEL_LIST[@]}"; do
         echo "--- [$CURRENT/$TOTAL_SCENARIOS] $DIR_NAME $MODE ---"
 
         # Executar análise
-        OUTPUT=$(iac analyze \
+        if OUTPUT=$(iac analyze \
             --base-dir "$BASE_DIR" \
             --issue-url "$ISSUE_URL" \
             --llm "$BACKEND" \
             --llm-model "$MODEL" \
-            --mode "$MODE" 2>&1)
+            --mode "$MODE" 2>&1); then
+            STATUS=0
+        else
+            STATUS=$?
+        fi
 
         # Extrair classificação do output
         CLASSIFICACAO=$(echo "$OUTPUT" | grep "^Classificação:" | head -1 || true)
         SUBCLASSIFICACAO=$(echo "$OUTPUT" | grep "^Subclassificação:" | head -1 || true)
         LABELS=$(echo "$OUTPUT" | grep "^Labels sugeridos:" | head -1 || true)
 
-        echo "  $CLASSIFICACAO"
-        [[ -n "$SUBCLASSIFICACAO" ]] && echo "  $SUBCLASSIFICACAO"
-        echo "  $LABELS"
+        if [[ "$STATUS" -eq 0 ]]; then
+            echo "  $CLASSIFICACAO"
+            [[ -n "$SUBCLASSIFICACAO" ]] && echo "  $SUBCLASSIFICACAO"
+            echo "  $LABELS"
+        else
+            echo "  Falha no cenário (exit=$STATUS)"
+        fi
 
         # Mover log gerado
         LATEST_LOG=$(ls -t "$LOGS_DIR"/iac_2026*.log 2>/dev/null | head -1)
@@ -148,7 +156,11 @@ for MODEL in "${MODEL_LIST[@]}"; do
         fi
 
         # Registrar resultado
-        RESULTS+="| $DIR_NAME | $MODE | $CLASSIFICACAO | $LABELS |\n"
+        if [[ "$STATUS" -eq 0 ]]; then
+            RESULTS+="| $DIR_NAME | $MODE | $CLASSIFICACAO | $LABELS |\n"
+        else
+            RESULTS+="| $DIR_NAME | $MODE | FALHA (exit=$STATUS) | - |\n"
+        fi
     done
     echo ""
 done

--- a/scripts/run_battery.sh
+++ b/scripts/run_battery.sh
@@ -25,6 +25,7 @@ BASE_DIR="."
 MODELS=""
 ISSUE_URL=""
 MODES="single multi loop"
+BACKEND=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -32,6 +33,7 @@ while [[ $# -gt 0 ]]; do
         --models) MODELS="$2"; shift 2 ;;
         --issue-url) ISSUE_URL="$2"; shift 2 ;;
         --modes) MODES="$2"; shift 2 ;;
+        --backend) BACKEND="$2"; shift 2 ;;
         *) echo "Argumento desconhecido: $1"; exit 1 ;;
     esac
 done
@@ -59,8 +61,10 @@ if [[ ! -d "$IAC_DIR" ]]; then
     exit 1
 fi
 
-# Detectar backend do .env
-BACKEND=$(grep -E "^IAC_LLM_BACKEND=" "$IAC_DIR/.env" 2>/dev/null | cut -d= -f2 || echo "groq")
+# Detectar backend do .env (se não informado via --backend)
+if [[ -z "$BACKEND" ]]; then
+    BACKEND=$(grep -E "^IAC_LLM_BACKEND=" "$IAC_DIR/.env" 2>/dev/null | cut -d= -f2 || echo "groq")
+fi
 
 # ---------------------------------------------------------------------------
 # Funções

--- a/scripts/run_battery.sh
+++ b/scripts/run_battery.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# =============================================================================
+# IAC — Bateria de testes LLM
+# =============================================================================
+# Executa os 3 modos (single, multi, loop) para cada modelo informado.
+# Logs salvos em .iac/logs/<backend>/<modelo>_{single,multi,loop}.log
+# Se já existirem logs, move para subpasta com datahora.
+#
+# Uso:
+#   ./scripts/run_battery.sh --base-dir /caminho/projeto --models "modelo1,modelo2"
+#   ./scripts/run_battery.sh --base-dir /caminho/projeto --models "llama-3.1-8b-instant,llama-3.3-70b-versatile"
+#   ./scripts/run_battery.sh --base-dir /caminho/projeto --models "llama-3.1-8b-instant" --issue-url URL
+#
+# Requer:
+#   - .iac/.env configurado (GITLAB_TOKEN, IAC_LLM_BACKEND, API key)
+#   - iac instalado (pip install -e .)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argumentos
+# ---------------------------------------------------------------------------
+
+BASE_DIR="."
+MODELS=""
+ISSUE_URL=""
+MODES="single multi loop"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --base-dir) BASE_DIR="$2"; shift 2 ;;
+        --models) MODELS="$2"; shift 2 ;;
+        --issue-url) ISSUE_URL="$2"; shift 2 ;;
+        --modes) MODES="$2"; shift 2 ;;
+        *) echo "Argumento desconhecido: $1"; exit 1 ;;
+    esac
+done
+
+if [[ -z "$MODELS" ]]; then
+    echo "Uso: $0 --base-dir DIR --models 'modelo1,modelo2' --issue-url URL"
+    echo ""
+    echo "Exemplo:"
+    echo "  $0 --base-dir /home/user/suap --models 'llama-3.1-8b-instant,llama-3.3-70b-versatile' \\"
+    echo "     --issue-url https://gitlab.example.com/project/-/work_items/16118"
+    exit 1
+fi
+
+if [[ -z "$ISSUE_URL" ]]; then
+    echo "Erro: --issue-url é obrigatório"
+    exit 1
+fi
+
+BASE_DIR=$(realpath "$BASE_DIR")
+IAC_DIR="$BASE_DIR/.iac"
+LOGS_DIR="$IAC_DIR/logs"
+
+if [[ ! -d "$IAC_DIR" ]]; then
+    echo "Erro: $IAC_DIR não encontrado. Execute 'iac init' primeiro."
+    exit 1
+fi
+
+# Detectar backend do .env
+BACKEND=$(grep -E "^IAC_LLM_BACKEND=" "$IAC_DIR/.env" 2>/dev/null | cut -d= -f2 || echo "groq")
+
+# ---------------------------------------------------------------------------
+# Funções
+# ---------------------------------------------------------------------------
+
+# Nome curto para diretório (remove prefixos e caracteres especiais)
+model_dir_name() {
+    local model="$1"
+    echo "$model" | sed 's|.*/||' | sed 's|[:/]|_|g'
+}
+
+# Backup de logs existentes
+backup_existing_logs() {
+    local model_logs_dir="$1"
+    if [[ -d "$model_logs_dir" ]] && ls "$model_logs_dir"/*.log &>/dev/null; then
+        local backup_name
+        backup_name=$(date +"%Y%m%d_%H%M%S")
+        local backup_dir="$model_logs_dir/$backup_name"
+        mkdir -p "$backup_dir"
+        mv "$model_logs_dir"/*.log "$backup_dir/" 2>/dev/null || true
+        echo "  Logs anteriores movidos para $backup_name/"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Execução
+# ---------------------------------------------------------------------------
+
+echo "=============================================="
+echo " IAC — Bateria de testes LLM"
+echo "=============================================="
+echo " Base dir:  $BASE_DIR"
+echo " Backend:   $BACKEND"
+echo " Issue URL: $ISSUE_URL"
+echo " Modelos:   $MODELS"
+echo " Modos:     $MODES"
+echo "=============================================="
+echo ""
+
+IFS=',' read -ra MODEL_LIST <<< "$MODELS"
+TOTAL_SCENARIOS=$(( ${#MODEL_LIST[@]} * $(echo "$MODES" | wc -w) ))
+CURRENT=0
+RESULTS=""
+
+for MODEL in "${MODEL_LIST[@]}"; do
+    MODEL=$(echo "$MODEL" | xargs)  # trim
+    DIR_NAME=$(model_dir_name "$MODEL")
+    MODEL_LOGS="$LOGS_DIR/$DIR_NAME"
+
+    echo "=== $MODEL ==="
+
+    # Backup logs existentes
+    mkdir -p "$MODEL_LOGS"
+    backup_existing_logs "$MODEL_LOGS"
+
+    for MODE in $MODES; do
+        CURRENT=$((CURRENT + 1))
+        echo "--- [$CURRENT/$TOTAL_SCENARIOS] $DIR_NAME $MODE ---"
+
+        # Executar análise
+        OUTPUT=$(iac analyze \
+            --base-dir "$BASE_DIR" \
+            --issue-url "$ISSUE_URL" \
+            --llm "$BACKEND" \
+            --llm-model "$MODEL" \
+            --mode "$MODE" 2>&1)
+
+        # Extrair classificação do output
+        CLASSIFICACAO=$(echo "$OUTPUT" | grep "^Classificação:" | head -1 || true)
+        SUBCLASSIFICACAO=$(echo "$OUTPUT" | grep "^Subclassificação:" | head -1 || true)
+        LABELS=$(echo "$OUTPUT" | grep "^Labels sugeridos:" | head -1 || true)
+
+        echo "  $CLASSIFICACAO"
+        [[ -n "$SUBCLASSIFICACAO" ]] && echo "  $SUBCLASSIFICACAO"
+        echo "  $LABELS"
+
+        # Mover log gerado
+        LATEST_LOG=$(ls -t "$LOGS_DIR"/iac_2026*.log 2>/dev/null | head -1)
+        if [[ -n "$LATEST_LOG" ]]; then
+            mv "$LATEST_LOG" "$MODEL_LOGS/${DIR_NAME}_${MODE}.log"
+        fi
+
+        # Registrar resultado
+        RESULTS+="| $DIR_NAME | $MODE | $CLASSIFICACAO | $LABELS |\n"
+    done
+    echo ""
+done
+
+echo "=============================================="
+echo " BATERIA COMPLETA — $TOTAL_SCENARIOS cenários"
+echo "=============================================="
+echo ""
+echo "| Modelo | Modo | Classificação | Labels |"
+echo "|--------|------|---------------|--------|"
+echo -e "$RESULTS"
+echo ""
+echo "Logs em: $LOGS_DIR/"
+ls -d "$LOGS_DIR"/*/  2>/dev/null

--- a/src/iac/agent/loop.py
+++ b/src/iac/agent/loop.py
@@ -20,7 +20,7 @@ from iac.agent.structural import format_structural_analysis
 
 logger = logging.getLogger(__name__)
 
-PROMPT_LOOP = """Você é um engenheiro de software sênior investigando uma issue de erro de produção do SUAP (ERP Django).
+PROMPT_LOOP = """Você é um engenheiro de software sênior investigando uma issue de erro de produção de um sistema {system_description}.
 
 {context}
 
@@ -35,8 +35,7 @@ Analise o que você já sabe e escolha UMA ação.
 ## Regras importantes
 - NÃO repita investigações já feitas (veja o histórico acima)
 - Se já tem código + constantes + descrição do usuário, avance para CLASSIFICAR
-- Se o interessado é Aluno e a view é de área discente, não assuma erro de permissão sem evidência explícita
-- Se a descrição menciona "tempo", "prazo", "hábil" ou "período", priorize constantes temporais (TEMPO_*, PRAZO_*, DIAS_*)
+{rules}
 - Correlacione a descrição do usuário com constantes do código (ex: "tempo hábil" → TEMPO_AVALIACAO)
 - Se precisa confirmar com dados reais, use VERIFICAR_BANCO (não INVESTIGAR)
 
@@ -109,6 +108,7 @@ def run_loop(
     max_iterations: int = 4,
     min_iterations: int = 2,
     initial_history: str | None = None,
+    profile: dict | None = None,
 ) -> dict:
     """Executa loop interativo de análise.
 
@@ -159,7 +159,11 @@ def run_loop(
             history += '\n\n⚠️ **Esta é a última iteração. Você DEVE responder com AÇÃO: CLASSIFICAR.**'
 
         # Enviar prompt
-        prompt = PROMPT_LOOP.format(context=base_context, history=history)
+        _profile = profile or {}
+        system_desc = _profile.get('system_description', 'Django')
+        rules = _profile.get('rules', [])
+        rules_text = '\n'.join(f'- {r}' for r in rules) if rules else ''
+        prompt = PROMPT_LOOP.format(context=base_context, history=history, system_description=system_desc, rules=rules_text)
         logger.info(f'[Loop iteração {iteration}] Prompt: {len(prompt)} chars → enviando ao {llm}')
         logger.debug(f'[Loop iteração {iteration}] Prompt conteúdo:\n{prompt}')
 

--- a/src/iac/agent/loop.py
+++ b/src/iac/agent/loop.py
@@ -35,6 +35,8 @@ Analise o que você já sabe e escolha UMA ação.
 ## Regras importantes
 - NÃO repita investigações já feitas (veja o histórico acima)
 - Se já tem código + constantes + descrição do usuário, avance para CLASSIFICAR
+- Se o interessado é Aluno e a view é de área discente, não assuma erro de permissão sem evidência explícita
+- Se a descrição menciona "tempo", "prazo", "hábil" ou "período", priorize constantes temporais (TEMPO_*, PRAZO_*, DIAS_*)
 - Correlacione a descrição do usuário com constantes do código (ex: "tempo hábil" → TEMPO_AVALIACAO)
 - Se precisa confirmar com dados reais, use VERIFICAR_BANCO (não INVESTIGAR)
 

--- a/src/iac/agent/loop.py
+++ b/src/iac/agent/loop.py
@@ -14,7 +14,7 @@ import re
 
 from iac.agent.format import format_context_for_prompt
 from iac.agent.prompts.multi import parse_investigation_requests, resolve_investigation_requests
-from iac.agent.prompts.utils import KNOWN_TIPOS, extract_tipo_from_analysis, normalize_to_known
+from iac.agent.prompts.utils import extract_tipo_from_analysis, normalize_to_known
 from iac.agent.runner import send_to_llm
 from iac.agent.structural import format_structural_analysis
 
@@ -131,6 +131,11 @@ def run_loop(
     if deep_constants:
         base_context += '\n---\n' + deep_constants
 
+    # Taxonomia do profile
+    _profile = profile or {}
+    _taxonomy = _profile.get('taxonomy', {})
+    _known_tipos = _taxonomy.get('known_tipos', set())
+
     history_entries = []
     if initial_history:
         history_entries.append(initial_history)
@@ -180,7 +185,7 @@ def run_loop(
         logger.info(f'[Loop iteração {iteration}] Ação: {action}')
 
         if action == 'CLASSIFICAR':
-            tipo_candidate = extract_tipo_from_analysis(response)
+            tipo_candidate = extract_tipo_from_analysis(response, profile=_profile)
 
             # Impedir classificação prematura (antes de min_iterations)
             if iteration < min_iterations and not force_classify:
@@ -193,15 +198,15 @@ def run_loop(
                 continue
 
             # Validar taxonomia — normalizar label se fora do catálogo
-            if tipo_candidate and tipo_candidate not in KNOWN_TIPOS:
-                normalized = normalize_to_known(tipo_candidate)
+            if tipo_candidate and tipo_candidate not in _known_tipos:
+                normalized = normalize_to_known(tipo_candidate, profile=_profile)
                 if normalized:
                     logger.info(f'[Loop] Label normalizado: {tipo_candidate} → {normalized}')
                     tipo_candidate = normalized
 
             # Se não extraiu tipo, tentar repair prompt
             if not tipo_candidate:
-                tipo_candidate = _repair_classification(response, llm, llm_model, llm_url, llm_key)
+                tipo_candidate = _repair_classification(response, llm, llm_model, llm_url, llm_key, profile=_profile)
 
             final_analysis = response
             final_tipo = tipo_candidate
@@ -255,12 +260,12 @@ def run_loop(
 
         else:
             # Ação não reconhecida — tentar extrair classificação mesmo assim
-            tipo = extract_tipo_from_analysis(response)
+            tipo = extract_tipo_from_analysis(response, profile=_profile)
             if not tipo:
-                tipo = _repair_classification(response, llm, llm_model, llm_url, llm_key)
+                tipo = _repair_classification(response, llm, llm_model, llm_url, llm_key, profile=_profile)
             if tipo:
-                if tipo not in KNOWN_TIPOS:
-                    normalized = normalize_to_known(tipo)
+                if tipo not in _known_tipos:
+                    normalized = normalize_to_known(tipo, profile=_profile)
                     if normalized:
                         tipo = normalized
                 final_analysis = response
@@ -273,7 +278,7 @@ def run_loop(
     if not final_analysis and history_entries:
         logger.warning(f'[Loop] Max iterações ({max_iterations}) sem CLASSIFICAR — forçando')
         final_analysis = '\n---\n'.join(history_entries)
-        final_tipo = extract_tipo_from_analysis(final_analysis)
+        final_tipo = extract_tipo_from_analysis(final_analysis, profile=_profile)
 
     return {
         'analysis': final_analysis,
@@ -363,7 +368,7 @@ def _enrich_on_repeat(req: dict, structure: dict, graph: dict, base_dir) -> str:
     return '\n'.join(sections)
 
 
-def _repair_classification(response: str, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None) -> str | None:
+def _repair_classification(response: str, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None, profile: dict | None = None) -> str | None:
     """Tenta extrair classificação via repair prompt curto."""
     snippet = response[:1500]
     prompt = PROMPT_REPAIR.format(analysis_snippet=snippet)
@@ -371,7 +376,7 @@ def _repair_classification(response: str, llm: str, llm_model: str, llm_url: str
     repair_response = send_to_llm(prompt, llm, llm_model, llm_url, llm_key)
     if not repair_response:
         return None
-    tipo = extract_tipo_from_analysis(repair_response)
+    tipo = extract_tipo_from_analysis(repair_response, profile=profile)
     if tipo:
         logger.info(f'[Loop] Repair extraiu: {tipo}')
     return tipo

--- a/src/iac/agent/orchestrator.py
+++ b/src/iac/agent/orchestrator.py
@@ -86,6 +86,7 @@ def analyze_issue(
     max_steps: int | None = None,
     max_context_chars: int | None = None,
     max_refs: int | None = None,
+    profile: dict | None = None,
 ) -> dict:
     """Ponto de entrada único para análise completa de um incidente.
 
@@ -101,6 +102,7 @@ def analyze_issue(
         max_steps: Sobrescreve o limite de passos do perfil.
         max_context_chars: Sobrescreve o limite de contexto do perfil.
         max_refs: Sobrescreve o limite de referências do perfil.
+        profile: Perfil do cliente (.iac/profile.yaml).
 
     Returns:
         Dict com classification, context, structural, deep e profile.
@@ -115,7 +117,7 @@ def analyze_issue(
 
     # Camada 1: Classifier
     logger.info('[Camada 1] Classifier — extraindo metadados da descrição')
-    classification = classify(title, description)
+    classification = classify(title, description, profile=profile)
     logger.info(f'[Camada 1] Resultado: origem={classification["origem"]}, app={classification.get("app")}, erro_id={classification.get("erro_id")}')
     logger.debug('[Camada 1] Classifier retornou:\n' + fmt_dict(classification))
 

--- a/src/iac/agent/orchestrator.py
+++ b/src/iac/agent/orchestrator.py
@@ -107,17 +107,18 @@ def analyze_issue(
     Returns:
         Dict com classification, context, structural, deep e profile.
     """
-    profile = get_model_profile(model_name)
-    _max_steps = max_steps or profile['max_steps']
-    _max_context_chars = max_context_chars or profile['max_context_chars']
-    _max_refs = max_refs or profile['max_refs']
+    client_profile = profile or {}
+    model_profile = get_model_profile(model_name)
+    _max_steps = max_steps or model_profile['max_steps']
+    _max_context_chars = max_context_chars or model_profile['max_context_chars']
+    _max_refs = max_refs or model_profile['max_refs']
 
     logger.info(f'[analyze_issue] Entrada: title="{title}", model={model_name}')
     logger.debug(f'[analyze_issue] Perfil: steps={_max_steps}, context={_max_context_chars}, refs={_max_refs}')
 
     # Camada 1: Classifier
     logger.info('[Camada 1] Classifier — extraindo metadados da descrição')
-    classification = classify(title, description, profile=profile)
+    classification = classify(title, description, profile=client_profile)
     logger.info(f'[Camada 1] Resultado: origem={classification["origem"]}, app={classification.get("app")}, erro_id={classification.get("erro_id")}')
     logger.debug('[Camada 1] Classifier retornou:\n' + fmt_dict(classification))
 
@@ -148,9 +149,9 @@ def analyze_issue(
     logger.info('[Camada 4] Deep — navegando FKs em profundidade')
     deep = deep_investigate(
         ctx, structure, graph, base_dir,
-        max_depth=profile['deep_max_depth'],
-        max_context_chars=profile['deep_max_context_chars'],
-        include_methods=profile['deep_include_methods'],
+        max_depth=model_profile['deep_max_depth'],
+        max_context_chars=model_profile['deep_max_context_chars'],
+        include_methods=model_profile['deep_include_methods'],
     )
     logger.info(f'[Camada 4] Resultado: {len(deep)} models em profundidade')
     logger.debug('[Camada 4] models:\n' + '\n'.join(
@@ -164,7 +165,7 @@ def analyze_issue(
         'context': ctx,
         'structural': structural,
         'deep': deep,
-        'profile': profile,
+        'profile': model_profile,
     }
 
 

--- a/src/iac/agent/prompts/analysis.py
+++ b/src/iac/agent/prompts/analysis.py
@@ -10,8 +10,8 @@ from iac.agent.format import format_context_for_prompt
 from iac.agent.prompts.utils import _strip_context_header
 from iac.agent.structural import format_structural_analysis
 
-SYSTEM_ANALYSIS = """Você é um engenheiro de software sênior analisando uma issue de erro de produção do SUAP \
-(ERP Django, Python 3.14, Django 5.2, 100+ apps).
+SYSTEM_ANALYSIS = """Você é um engenheiro de software sênior analisando uma issue de erro de produção \
+de um sistema {system_description}.
 
 Você receberá:
 - Dados da issue (extraídos automaticamente da descrição)
@@ -64,21 +64,29 @@ REGRAS:
 - Não invente código inexistente
 - Use [ENCONTRADO] para evidências e [INFERÊNCIA] para hipóteses
 - Correlacione sempre a descrição do usuário com o código analisado
-- Se o interessado é Aluno e a view é de área discente, não assuma erro de permissão a menos que haja evidência explícita de exceção/acesso negado
-- Se a descrição menciona "tempo", "prazo", "hábil" ou "período", priorize investigar constantes temporais (TEMPO_*, PRAZO_*, DIAS_*)"""
+{rules}"""
 
 
-def build_analysis_prompt(result: dict, include_deep: bool = True) -> str:
+def build_analysis_prompt(result: dict, include_deep: bool = True, profile: dict | None = None) -> str:
     """Constrói o prompt de análise completo (modo single-prompt).
 
     Args:
         result: Dict retornado por analyze_issue() com structural, context e deep.
-        include_deep: Se False, omite a análise profunda do prompt (útil para modelos pequenos).
+        include_deep: Se False, omite a análise profunda do prompt.
+        profile: Perfil do cliente (.iac/profile.yaml) com system_description e rules.
 
     Returns:
         Prompt completo para enviar ao LLM.
     """
-    sections = [SYSTEM_ANALYSIS, '\n---\n']
+    profile = profile or {}
+    system_desc = profile.get('system_description', 'Django')
+    rules = profile.get('rules', [])
+    rules_text = '\n'.join(f'- {r}' for r in rules) if rules else ''
+
+    system = SYSTEM_ANALYSIS.format(system_description=system_desc)
+    template = TEMPLATE_ANALYSIS.format(rules=rules_text)
+
+    sections = [system, '\n---\n']
 
     structural_text = format_structural_analysis(result['structural'])
     sections.append(structural_text)
@@ -98,6 +106,6 @@ def build_analysis_prompt(result: dict, include_deep: bool = True) -> str:
                 sections.append(deep_text)
 
     sections.append('\n---\n')
-    sections.append(TEMPLATE_ANALYSIS)
+    sections.append(template)
 
     return '\n'.join(sections)

--- a/src/iac/agent/prompts/analysis.py
+++ b/src/iac/agent/prompts/analysis.py
@@ -63,7 +63,9 @@ REGRAS:
 - Seja conciso e baseie-se apenas no código fornecido
 - Não invente código inexistente
 - Use [ENCONTRADO] para evidências e [INFERÊNCIA] para hipóteses
-- Correlacione sempre a descrição do usuário com o código analisado"""
+- Correlacione sempre a descrição do usuário com o código analisado
+- Se o interessado é Aluno e a view é de área discente, não assuma erro de permissão a menos que haja evidência explícita de exceção/acesso negado
+- Se a descrição menciona "tempo", "prazo", "hábil" ou "período", priorize investigar constantes temporais (TEMPO_*, PRAZO_*, DIAS_*)"""
 
 
 def build_analysis_prompt(result: dict, include_deep: bool = True) -> str:

--- a/src/iac/agent/prompts/multi.py
+++ b/src/iac/agent/prompts/multi.py
@@ -82,7 +82,11 @@ Para confirmar a análise, indique o que verificar:
 - **O que verificar no banco:** dados a consultar para confirmar a hipótese
 - **O que verificar como admin:** ação administrativa para validar
 
-REGRAS: Seja conciso. Use apenas o código fornecido. Não invente código. Correlacione sempre a descrição do usuário com o código."""
+REGRAS:
+- Seja conciso. Use apenas o código fornecido. Não invente código.
+- Correlacione sempre a descrição do usuário com o código.
+- Se o interessado é Aluno e a view é de área discente, não assuma erro de permissão sem evidência explícita.
+- Se a descrição menciona "tempo", "prazo", "hábil" ou "período", priorize constantes temporais (TEMPO_*, PRAZO_*, DIAS_*)."""
 
 
 def build_investigation_prompt(result: dict) -> str:

--- a/src/iac/agent/prompts/multi.py
+++ b/src/iac/agent/prompts/multi.py
@@ -85,6 +85,7 @@ Para confirmar a análise, indique o que verificar:
 REGRAS:
 - Seja conciso. Use apenas o código fornecido. Não invente código.
 - Correlacione sempre a descrição do usuário com o código.
+- Se há evidência temporal (constantes TEMPO_*, datas, prazos) E evidência de acesso (PermissionDenied, eh_aluno), priorize a temporal como causa raiz — checks de acesso são geralmente gates de segurança, não causa do problema reportado.
 {rules}"""
 
 

--- a/src/iac/agent/prompts/multi.py
+++ b/src/iac/agent/prompts/multi.py
@@ -14,7 +14,7 @@ from iac.agent.structural import format_structural_analysis
 
 logger = logging.getLogger(__name__)
 
-PROMPT_INVESTIGATION = """Você é um engenheiro de software sênior investigando uma issue de erro de produção do SUAP (ERP Django).
+PROMPT_INVESTIGATION = """Você é um engenheiro de software sênior investigando uma issue de erro de produção de um sistema {system_description}.
 
 Analise os dados abaixo e o código da view. Depois, liste exatamente o que você PRECISA VER para entender a causa raiz.
 
@@ -85,19 +85,22 @@ Para confirmar a análise, indique o que verificar:
 REGRAS:
 - Seja conciso. Use apenas o código fornecido. Não invente código.
 - Correlacione sempre a descrição do usuário com o código.
-- Se o interessado é Aluno e a view é de área discente, não assuma erro de permissão sem evidência explícita.
-- Se a descrição menciona "tempo", "prazo", "hábil" ou "período", priorize constantes temporais (TEMPO_*, PRAZO_*, DIAS_*)."""
+{rules}"""
 
 
-def build_investigation_prompt(result: dict) -> str:
+def build_investigation_prompt(result: dict, profile: dict | None = None) -> str:
     """Prompt 1: LLM analisa a view e lista o que precisa investigar.
 
     Args:
         result: Dict retornado por analyze_issue() com structural e context.
+        profile: Perfil do cliente (.iac/profile.yaml).
 
     Returns:
         Prompt formatado para enviar ao LLM no modo multi-prompt.
     """
+    profile = profile or {}
+    system_desc = profile.get('system_description', 'Django')
+
     structural_text = format_structural_analysis(result['structural'])
     context_text = format_context_for_prompt(result['context'])
     context_text = _strip_context_header(context_text)
@@ -106,7 +109,7 @@ def build_investigation_prompt(result: dict) -> str:
     if context_text.strip():
         context += '\n---\n' + context_text
 
-    return PROMPT_INVESTIGATION.format(context=context)
+    return PROMPT_INVESTIGATION.format(context=context, system_description=system_desc)
 
 
 def parse_investigation_requests(llm_response: str) -> list[dict]:
@@ -294,18 +297,23 @@ def resolve_investigation_requests(requests: list[dict], structure: dict, graph:
     return '\n'.join(sections)
 
 
-def build_evidence_prompt(evidence: str, view_context: str | None = None) -> str:
+def build_evidence_prompt(evidence: str, view_context: str | None = None, profile: dict | None = None) -> str:
     """Prompt 2: LLM recebe código adicional e faz análise completa.
 
     Args:
         evidence: Código dos models/métodos investigados.
         view_context: Código da view (do prompt 1, para não perder contexto).
+        profile: Perfil do cliente (.iac/profile.yaml).
 
     Returns:
         Prompt formatado com evidência + instruções de análise.
     """
+    profile = profile or {}
+    rules = profile.get('rules', [])
+    rules_text = '\n'.join(f'- {r}' for r in rules) if rules else ''
+
     full_evidence = ''
     if view_context:
         full_evidence += view_context + '\n\n---\n\n'
     full_evidence += evidence
-    return PROMPT_EVIDENCE.format(evidence=full_evidence)
+    return PROMPT_EVIDENCE.format(evidence=full_evidence, rules=rules_text)

--- a/src/iac/agent/prompts/response.py
+++ b/src/iac/agent/prompts/response.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from iac.agent.prompts.utils import extract_tipo_from_analysis
 
-PROMPT_RESPONSE = """Você é um engenheiro de software sênior do SUAP (ERP Django) \
+PROMPT_RESPONSE = """Você é um engenheiro de software sênior de um sistema {system_description} \
 produzindo um relatório técnico sobre um incidente reportado.
 
 Com base na análise abaixo, gere um relatório conciso para o desenvolvedor que vai tratar o chamado.
@@ -36,16 +36,20 @@ Com base na análise abaixo, gere um relatório conciso para o desenvolvedor que
 {analise}"""
 
 
-def build_response_prompt(result: dict, llm_analysis: str) -> str:
-    """Constrói o prompt de resposta ao usuário.
+def build_response_prompt(result: dict, llm_analysis: str, profile: dict | None = None) -> str:
+    """Constrói o prompt de relatório técnico.
 
     Args:
         result: Dict retornado por analyze_issue() com classification.
         llm_analysis: Texto da análise produzida pelo LLM.
+        profile: Perfil do cliente (.iac/profile.yaml).
 
     Returns:
-        Prompt para o LLM gerar o rascunho de resposta.
+        Prompt para o LLM gerar o relatório técnico.
     """
+    profile = profile or {}
+    system_desc = profile.get('system_description', 'Django')
+
     classification = result['classification']
     nome = classification.get('interessado', 'Usuário')
     tipo = extract_tipo_from_analysis(llm_analysis) or classification.get('tipo_sugerido', 'não classificado')
@@ -54,4 +58,5 @@ def build_response_prompt(result: dict, llm_analysis: str) -> str:
         nome=nome,
         tipo=tipo,
         analise=llm_analysis,
+        system_description=system_desc,
     )

--- a/src/iac/agent/prompts/response.py
+++ b/src/iac/agent/prompts/response.py
@@ -52,7 +52,7 @@ def build_response_prompt(result: dict, llm_analysis: str, profile: dict | None 
 
     classification = result['classification']
     nome = classification.get('interessado', 'Usuário')
-    tipo = extract_tipo_from_analysis(llm_analysis) or classification.get('tipo_sugerido', 'não classificado')
+    tipo = extract_tipo_from_analysis(llm_analysis, profile=profile) or classification.get('tipo_sugerido', 'não classificado')
 
     return PROMPT_RESPONSE.format(
         nome=nome,

--- a/src/iac/agent/prompts/utils.py
+++ b/src/iac/agent/prompts/utils.py
@@ -11,6 +11,22 @@ KNOWN_TIPOS = {
     'tipo::dados-cadastrais',
     'tipo::prazo-expirado',
     'tipo::nao-e-erro',
+    'tipo::permissao',
+}
+
+# Labels "nus" (sem tipo::) aceitos pelo parser — mapeiam para tipo::*
+_BARE_LABELS = {
+    'bug': 'tipo::bug',
+    'configuracao': 'tipo::configuracao',
+    'configuração': 'tipo::configuracao',
+    'dados-cadastrais': 'tipo::dados-cadastrais',
+    'prazo-expirado': 'tipo::prazo-expirado',
+    'nao-e-erro': 'tipo::nao-e-erro',
+    'não é erro': 'tipo::nao-e-erro',
+    'permissao': 'tipo::permissao',
+    'permissão': 'tipo::permissao',
+    'logica-incorreta': 'tipo::bug',
+    'comportamento-esperado': 'tipo::nao-e-erro',
 }
 
 
@@ -86,22 +102,17 @@ def extract_classificacao(analysis: str) -> dict:
     match = re.search(r'CLASSIFICA[CÇ][AÃ]O:\s*(.+?)(?:\n|/|$)', clean)
     if match:
         raw = match.group(1).strip()
-        if '::' in raw:
-            classificacao = _normalize_label(raw)
-        # Checar se tem subclassificação na mesma linha: CLASSIFICAÇÃO: x / SUBCLASSIFICAÇÃO: y
+        classificacao = _resolve_label(raw)
+        # Checar subclassificação inline ou em linhas seguintes
         sub_inline = re.search(r'SUBCLASSIFICA[CÇ][AÃ]O:\s*(.+?)(?:\n|$)', clean[match.end():])
         if sub_inline:
-            raw_sub = sub_inline.group(1).strip()
-            if '::' in raw_sub:
-                subclassificacao = _normalize_label(raw_sub)
+            subclassificacao = _resolve_label(sub_inline.group(1).strip())
 
     # Fallback: SUBCLASSIFICAÇÃO em linha separada
     if not subclassificacao:
         match_sub = re.search(r'SUBCLASSIFICA[CÇ][AÃ]O:\s*(.+?)(?:\n|$)', clean)
         if match_sub:
-            raw_sub = match_sub.group(1).strip()
-            if '::' in raw_sub:
-                subclassificacao = _normalize_label(raw_sub)
+            subclassificacao = _resolve_label(match_sub.group(1).strip())
 
     # Fallback: tipo::nome no texto (sem CLASSIFICAÇÃO:)
     if not classificacao:
@@ -109,22 +120,58 @@ def extract_classificacao(analysis: str) -> dict:
         if match_tipo:
             classificacao = match_tipo.group(1).strip()
 
+    # Normalizar subclassificação para labels conhecidos
+    if subclassificacao and subclassificacao not in KNOWN_TIPOS:
+        normalized = normalize_to_known(subclassificacao)
+        if normalized:
+            subclassificacao = normalized
+
     return {
         'classificacao': classificacao,
         'subclassificacao': subclassificacao,
     }
 
 
+def _resolve_label(raw: str) -> str | None:
+    """Resolve um label bruto — com ou sem prefixo tipo::.
+
+    Aceita: 'tipo::bug', 'Bug::Avaliação', 'bug', 'logica-incorreta'.
+    """
+    if '::' in raw:
+        return _normalize_label(raw)
+    # Label "nu" — tentar mapear
+    bare = raw.lower().strip()
+    if bare in _BARE_LABELS:
+        return _BARE_LABELS[bare]
+    # Tentar normalizar como se fosse tipo::
+    normalized = _normalize_label(f'tipo::{raw}')
+    if normalized and normalized in KNOWN_TIPOS:
+        return normalized
+    return _normalize_label(f'tipo::{raw}')
+
+
 # Mapeamento de labels comuns fora do catálogo → label conhecido
 _LABEL_ALIASES = {
+    # prazo-expirado
     'tipo::avaliacao-nao-disponivel': 'tipo::prazo-expirado',
     'tipo::prazo-avaliacao': 'tipo::prazo-expirado',
     'tipo::tempo-expirado': 'tipo::prazo-expirado',
     'tipo::tempo-esgotado': 'tipo::prazo-expirado',
+    'tipo::tempo-de-execucao-insuficiente': 'tipo::prazo-expirado',
+    'tipo::tempo-insuficiente-para-avaliacao': 'tipo::prazo-expirado',
+    'tipo::tempo-habil-para-avaliacao': 'tipo::prazo-expirado',
+    'tipo::tempo-de-avaliacao-expirado': 'tipo::prazo-expirado',
+    'tipo::tempo-de-avaliacao-insuficiente': 'tipo::prazo-expirado',
+    # bug
     'tipo::validacao-falhada': 'tipo::bug',
     'tipo::logica-incorreta': 'tipo::bug',
     'tipo::excecao-nao-tratada': 'tipo::bug',
     'tipo::erro-de-codigo': 'tipo::bug',
+    'tipo::erro-de-negocio': 'tipo::bug',
+    # nao-e-erro
+    'tipo::comportamento-esperado': 'tipo::nao-e-erro',
+    'tipo::filtro-avaliacoes': 'tipo::nao-e-erro',
+    # permissao
     'tipo::acesso-negado': 'tipo::permissao',
     'tipo::sem-permissao': 'tipo::permissao',
 }

--- a/src/iac/agent/prompts/utils.py
+++ b/src/iac/agent/prompts/utils.py
@@ -1,33 +1,15 @@
-"""Utilitários de prompts — extração de tipo e compactação de código."""
+"""Utilitários de prompts — extração de tipo, taxonomia e compactação de código.
+
+Toda taxonomia (known_tipos, aliases) vem do profile (.iac/profile.yaml).
+Se nenhum profile for fornecido, usa defaults de settings.py.
+"""
 
 from __future__ import annotations
 
 import re
 import unicodedata
 
-KNOWN_TIPOS = {
-    'tipo::bug',
-    'tipo::configuracao',
-    'tipo::dados-cadastrais',
-    'tipo::prazo-expirado',
-    'tipo::nao-e-erro',
-    'tipo::permissao',
-}
-
-# Labels "nus" (sem tipo::) aceitos pelo parser — mapeiam para tipo::*
-_BARE_LABELS = {
-    'bug': 'tipo::bug',
-    'configuracao': 'tipo::configuracao',
-    'configuração': 'tipo::configuracao',
-    'dados-cadastrais': 'tipo::dados-cadastrais',
-    'prazo-expirado': 'tipo::prazo-expirado',
-    'nao-e-erro': 'tipo::nao-e-erro',
-    'não é erro': 'tipo::nao-e-erro',
-    'permissao': 'tipo::permissao',
-    'permissão': 'tipo::permissao',
-    'logica-incorreta': 'tipo::bug',
-    'comportamento-esperado': 'tipo::nao-e-erro',
-}
+from iac.config.settings import DEFAULT_ALIASES, DEFAULT_KNOWN_TIPOS
 
 
 def _normalize_label(raw: str) -> str:
@@ -39,60 +21,42 @@ def _normalize_label(raw: str) -> str:
     Returns:
         Label normalizado (ex: 'tipo::avaliacao-nao-preenchida').
     """
-    # Remover markdown
     raw = raw.strip('*').strip('`').strip()
 
-    # Separar prefixo e nome
     if '::' in raw:
         _prefix, nome = raw.split('::', 1)
     else:
         nome = raw
 
-    # Remover acentos
     nome = unicodedata.normalize('NFKD', nome).encode('ascii', 'ignore').decode('ascii')
-
-    # Lowercase, substituir espaços e underscores por hífens
     nome = nome.lower().strip()
     nome = re.sub(r'[\s_]+', '-', nome)
-
-    # Remover caracteres inválidos
     nome = re.sub(r'[^a-z0-9-]', '', nome)
-
-    # Remover hífens duplicados e nas pontas
     nome = re.sub(r'-+', '-', nome).strip('-')
 
     return f'tipo::{nome}' if nome else None
 
 
-def extract_tipo_from_analysis(analysis: str) -> str | None:
-    """Extrai o label principal de classificação da resposta do LLM.
-
-    Args:
-        analysis: Texto completo da resposta do LLM.
-
-    Returns:
-        Label tipo::* normalizado ou None.
-    """
-    result = extract_classificacao(analysis)
+def extract_tipo_from_analysis(analysis: str, profile: dict | None = None) -> str | None:
+    """Extrai o label principal de classificação da resposta do LLM."""
+    result = extract_classificacao(analysis, profile=profile)
     return result['classificacao']
 
 
-def extract_classificacao(analysis: str) -> dict:
+def extract_classificacao(analysis: str, profile: dict | None = None) -> dict:
     """Extrai classificação e subclassificação da resposta do LLM.
-
-    Procura padrões como::
-
-        CLASSIFICAÇÃO: tipo::nao-e-erro
-        SUBCLASSIFICAÇÃO: tipo::prazo-expirado
-
-    Ou formatos alternativos com markdown, prefixos variados, etc.
 
     Args:
         analysis: Texto completo da resposta do LLM.
+        profile: Perfil do cliente com taxonomy (known_tipos, aliases).
 
     Returns:
         Dict com classificacao (str|None) e subclassificacao (str|None).
     """
+    taxonomy = _get_taxonomy(profile)
+    known_tipos = taxonomy['known_tipos']
+    aliases = taxonomy['aliases']
+
     clean = analysis.replace('**', '').replace('`', '')
 
     classificacao = None
@@ -102,17 +66,16 @@ def extract_classificacao(analysis: str) -> dict:
     match = re.search(r'CLASSIFICA[CÇ][AÃ]O:\s*(.+?)(?:\n|/|$)', clean)
     if match:
         raw = match.group(1).strip()
-        classificacao = _resolve_label(raw)
-        # Checar subclassificação inline ou em linhas seguintes
+        classificacao = _resolve_label(raw, known_tipos, aliases)
         sub_inline = re.search(r'SUBCLASSIFICA[CÇ][AÃ]O:\s*(.+?)(?:\n|$)', clean[match.end():])
         if sub_inline:
-            subclassificacao = _resolve_label(sub_inline.group(1).strip())
+            subclassificacao = _resolve_label(sub_inline.group(1).strip(), known_tipos, aliases)
 
     # Fallback: SUBCLASSIFICAÇÃO em linha separada
     if not subclassificacao:
         match_sub = re.search(r'SUBCLASSIFICA[CÇ][AÃ]O:\s*(.+?)(?:\n|$)', clean)
         if match_sub:
-            subclassificacao = _resolve_label(match_sub.group(1).strip())
+            subclassificacao = _resolve_label(match_sub.group(1).strip(), known_tipos, aliases)
 
     # Fallback: tipo::nome no texto (sem CLASSIFICAÇÃO:)
     if not classificacao:
@@ -120,11 +83,11 @@ def extract_classificacao(analysis: str) -> dict:
         if match_tipo:
             classificacao = match_tipo.group(1).strip()
 
-    # Normalizar subclassificação para labels conhecidos
-    if subclassificacao and subclassificacao not in KNOWN_TIPOS:
-        normalized = normalize_to_known(subclassificacao)
-        if normalized:
-            subclassificacao = normalized
+    # Normalizar para labels conhecidos
+    if classificacao and classificacao not in known_tipos:
+        classificacao = aliases.get(classificacao, classificacao)
+    if subclassificacao and subclassificacao not in known_tipos:
+        subclassificacao = aliases.get(subclassificacao, subclassificacao)
 
     return {
         'classificacao': classificacao,
@@ -132,72 +95,47 @@ def extract_classificacao(analysis: str) -> dict:
     }
 
 
-def _resolve_label(raw: str) -> str | None:
-    """Resolve um label bruto — com ou sem prefixo tipo::.
+def normalize_to_known(tipo: str, profile: dict | None = None) -> str | None:
+    """Normaliza label fora do catálogo para o mais próximo conhecido."""
+    taxonomy = _get_taxonomy(profile)
+    return taxonomy['aliases'].get(tipo)
 
-    Aceita: 'tipo::bug', 'Bug::Avaliação', 'bug', 'logica-incorreta'.
-    """
+
+def _resolve_label(raw: str, known_tipos: set, aliases: dict) -> str | None:
+    """Resolve um label bruto — com ou sem prefixo tipo::."""
     if '::' in raw:
-        return _normalize_label(raw)
-    # Label "nu" — tentar mapear
-    bare = raw.lower().strip()
-    if bare in _BARE_LABELS:
-        return _BARE_LABELS[bare]
-    # Tentar normalizar como se fosse tipo::
-    normalized = _normalize_label(f'tipo::{raw}')
-    if normalized and normalized in KNOWN_TIPOS:
+        normalized = _normalize_label(raw)
+        if normalized and normalized not in known_tipos:
+            normalized = aliases.get(normalized, normalized)
         return normalized
-    return _normalize_label(f'tipo::{raw}')
+
+    # Label "nu" — normalizar e tentar resolver
+    normalized = _normalize_label(f'tipo::{raw}')
+    if not normalized:
+        return None
+    if normalized in known_tipos:
+        return normalized
+    return aliases.get(normalized, normalized)
 
 
-# Mapeamento de labels comuns fora do catálogo → label conhecido
-_LABEL_ALIASES = {
-    # prazo-expirado
-    'tipo::avaliacao-nao-disponivel': 'tipo::prazo-expirado',
-    'tipo::prazo-avaliacao': 'tipo::prazo-expirado',
-    'tipo::tempo-expirado': 'tipo::prazo-expirado',
-    'tipo::tempo-esgotado': 'tipo::prazo-expirado',
-    'tipo::tempo-de-execucao-insuficiente': 'tipo::prazo-expirado',
-    'tipo::tempo-insuficiente-para-avaliacao': 'tipo::prazo-expirado',
-    'tipo::tempo-habil-para-avaliacao': 'tipo::prazo-expirado',
-    'tipo::tempo-de-avaliacao-expirado': 'tipo::prazo-expirado',
-    'tipo::tempo-de-avaliacao-insuficiente': 'tipo::prazo-expirado',
-    # bug
-    'tipo::validacao-falhada': 'tipo::bug',
-    'tipo::logica-incorreta': 'tipo::bug',
-    'tipo::excecao-nao-tratada': 'tipo::bug',
-    'tipo::erro-de-codigo': 'tipo::bug',
-    'tipo::erro-de-negocio': 'tipo::bug',
-    # nao-e-erro
-    'tipo::comportamento-esperado': 'tipo::nao-e-erro',
-    'tipo::filtro-avaliacoes': 'tipo::nao-e-erro',
-    # permissao
-    'tipo::acesso-negado': 'tipo::permissao',
-    'tipo::sem-permissao': 'tipo::permissao',
-}
-
-
-def normalize_to_known(tipo: str) -> str | None:
-    """Normaliza label fora do catálogo para o mais próximo conhecido.
-
-    Args:
-        tipo: Label tipo::* fora de KNOWN_TIPOS.
-
-    Returns:
-        Label conhecido ou None se não houver mapeamento.
-    """
-    return _LABEL_ALIASES.get(tipo)
+def _get_taxonomy(profile: dict | None) -> dict:
+    """Extrai taxonomia do profile ou retorna defaults."""
+    if profile and 'taxonomy' in profile:
+        tax = profile['taxonomy']
+        known = tax.get('known_tipos', DEFAULT_KNOWN_TIPOS)
+        als = tax.get('aliases', DEFAULT_ALIASES)
+        return {
+            'known_tipos': set(known) if not isinstance(known, set) else known,
+            'aliases': dict(als),
+        }
+    return {
+        'known_tipos': set(DEFAULT_KNOWN_TIPOS),
+        'aliases': dict(DEFAULT_ALIASES),
+    }
 
 
 def compact_code(source: str) -> str:
-    """Compacta código removendo docstrings, comentários e linhas em branco.
-
-    Args:
-        source: Código-fonte Python original.
-
-    Returns:
-        Código compactado.
-    """
+    """Compacta código removendo docstrings, comentários e linhas em branco."""
     lines = source.splitlines()
     result = []
     in_docstring = False

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -183,8 +183,21 @@ def run_auto(result: dict, structure: dict, graph: dict, base_dir, llm: str, llm
             'mode_used': 'single',
         }
 
-    # Passo 3: escalar para loop com histórico do single
-    logger.info(f'[auto] Resposta incerta (confiança={confidence}/4) — escalando para loop')
+    # Passo 3: escalar para multi (mais estável que loop)
+    logger.info(f'[auto] Resposta incerta (confiança={confidence}/4) — escalando para multi')
+    multi_analysis = run_multi(result, structure, graph, base_dir, llm, llm_model, llm_url, llm_key, profile=profile)
+    if multi_analysis:
+        tipo = extract_tipo_from_analysis(multi_analysis, profile=profile)
+        return {
+            'analysis': multi_analysis,
+            'tipo': tipo,
+            'alteracoes': [],
+            'iterations': 0,
+            'mode_used': 'single+multi',
+        }
+
+    # Passo 4: se multi também falhou, escalar para loop
+    logger.info('[auto] Multi sem resposta — escalando para loop')
     initial_history = (
         f'**Prompt 0 — SINGLE (análise inicial)**\n\n'
         f'{single_analysis}\n\n'
@@ -197,7 +210,7 @@ def run_auto(result: dict, structure: dict, graph: dict, base_dir, llm: str, llm
         initial_history=initial_history,
         profile=profile,
     )
-    return {**loop_result, 'mode_used': 'single+loop'}
+    return {**loop_result, 'mode_used': 'single+multi+loop'}
 
 
 def _confidence_score(analysis: str) -> int:

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -72,23 +72,22 @@ def send_to_llm(prompt: str, llm: str, llm_model: str, llm_url: str | None, llm_
     return result
 
 
-def run_single(result: dict, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None) -> str | None:
+def run_single(result: dict, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None, profile: dict | None = None) -> str | None:
     """Executa análise em modo single-prompt com ajuste progressivo.
 
     Se o prompt for grande demais (413), reduz progressivamente:
     1. Com deep → 2. Sem deep → 3. Desiste.
     """
-    profile = get_model_profile(llm_model)
-    include_deep = profile.get('deep_include_methods', True)
-    prompt = build_analysis_prompt(result, include_deep=include_deep)
+    model_profile = get_model_profile(llm_model)
+    include_deep = model_profile.get('deep_include_methods', True)
+    prompt = build_analysis_prompt(result, include_deep=include_deep, profile=profile)
     logger.info(f'[LLM] Modo single-prompt: {len(prompt)} chars (deep={include_deep}) → enviando ao {llm} ({llm_model})')
 
     analysis = send_to_llm(prompt, llm, llm_model, llm_url, llm_key)
 
-    # Ajuste progressivo: se prompt grande demais, reduzir
     if analysis == 'PROMPT_TOO_LARGE' and include_deep:
         logger.info('[LLM] Prompt muito grande — retentando sem deep')
-        prompt = build_analysis_prompt(result, include_deep=False)
+        prompt = build_analysis_prompt(result, include_deep=False, profile=profile)
         logger.info(f'[LLM] Modo single-prompt (sem deep): {len(prompt)} chars → enviando ao {llm} ({llm_model})')
         analysis = send_to_llm(prompt, llm, llm_model, llm_url, llm_key)
 
@@ -100,26 +99,12 @@ def run_single(result: dict, llm: str, llm_model: str, llm_url: str | None, llm_
     return analysis
 
 
-def run_multi(result: dict, structure: dict, graph: dict, base_dir, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None) -> str | None:
-    """Executa análise em modo multi-prompt (investigação → evidência → análise).
-
-    Args:
-        result: Dict retornado por analyze_issue().
-        structure: Mapa estrutural (.iac/structure.json).
-        graph: Grafo de dependências (.iac/graph.json).
-        base_dir: Diretório raiz do projeto.
-        llm: Backend LLM.
-        llm_model: Nome do modelo.
-        llm_url: Endpoint da API.
-        llm_key: API key.
-
-    Returns:
-        Texto da análise do LLM ou None.
-    """
+def run_multi(result: dict, structure: dict, graph: dict, base_dir, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None, profile: dict | None = None) -> str | None:
+    """Executa análise em modo multi-prompt (investigação → evidência → análise)."""
     logger.info('[LLM] Modo multi-prompt iniciado')
 
     # Prompt 1: investigação
-    investigation_prompt = build_investigation_prompt(result)
+    investigation_prompt = build_investigation_prompt(result, profile=profile)
     logger.info(f'[LLM] Prompt 1 (investigação): {len(investigation_prompt)} chars → enviando ao {llm} ({llm_model})')
     logger.debug(f'[LLM] Prompt 1 (investigação) conteúdo:\n{investigation_prompt}')
 
@@ -139,7 +124,7 @@ def run_multi(result: dict, structure: dict, graph: dict, base_dir, llm: str, ll
 
     if not requests:
         logger.info('[LLM] Sem pedidos — fallback para single-prompt')
-        return run_single(result, llm, llm_model, llm_url, llm_key)
+        return run_single(result, llm, llm_model, llm_url, llm_key, profile=profile)
 
     # Resolver evidência
     evidence = resolve_investigation_requests(requests, structure, graph, base_dir)
@@ -160,7 +145,7 @@ def run_multi(result: dict, structure: dict, graph: dict, base_dir, llm: str, ll
     if deep_summary:
         evidence += '\n---\n' + deep_summary
 
-    evidence_prompt = build_evidence_prompt(evidence, view_context=view_context)
+    evidence_prompt = build_evidence_prompt(evidence, view_context=view_context, profile=profile)
     logger.info(f'[LLM] Prompt 2 (análise): {len(evidence_prompt)} chars → enviando ao {llm} ({llm_model})')
     logger.debug(f'[LLM] Prompt 2 (análise) conteúdo:\n{evidence_prompt}')
 
@@ -170,31 +155,17 @@ def run_multi(result: dict, structure: dict, graph: dict, base_dir, llm: str, ll
     return analysis
 
 
-def run_auto(result: dict, structure: dict, graph: dict, base_dir, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None) -> dict:
-    """Executa single como fast-path, escala para loop se incerto.
-
-    Args:
-        result: Dict retornado por analyze_issue().
-        structure: Mapa estrutural (.iac/structure.json).
-        graph: Grafo de dependências (.iac/graph.json).
-        base_dir: Diretório raiz do projeto.
-        llm: Backend LLM.
-        llm_model: Nome do modelo.
-        llm_url: Endpoint da API.
-        llm_key: API key.
-
-    Returns:
-        Dict com analysis, tipo, alteracoes, mode_used.
-    """
+def run_auto(result: dict, structure: dict, graph: dict, base_dir, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None, profile: dict | None = None) -> dict:
+    """Executa single como fast-path, escala para loop se incerto."""
     from iac.agent.loop import run_loop
 
     # Passo 1: single como Prompt 0
     logger.info('[auto] Passo 1: single como fast-path')
-    single_analysis = run_single(result, llm, llm_model, llm_url, llm_key)
+    single_analysis = run_single(result, llm, llm_model, llm_url, llm_key, profile=profile)
 
     if not single_analysis:
         logger.warning('[auto] Single sem resposta — fallback para loop')
-        loop_result = run_loop(result, structure, graph, base_dir, llm, llm_model, llm_url, llm_key)
+        loop_result = run_loop(result, structure, graph, base_dir, llm, llm_model, llm_url, llm_key, profile=profile)
         return {**loop_result, 'mode_used': 'loop'}
 
     # Passo 2: avaliar confiança
@@ -224,6 +195,7 @@ def run_auto(result: dict, structure: dict, graph: dict, base_dir, llm: str, llm
         result, structure, graph, base_dir,
         llm, llm_model, llm_url, llm_key,
         initial_history=initial_history,
+        profile=profile,
     )
     return {**loop_result, 'mode_used': 'single+loop'}
 
@@ -266,21 +238,9 @@ def _confidence_score(analysis: str) -> int:
     return score
 
 
-def run_response(result: dict, llm_analysis: str, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None) -> str | None:
-    """Gera rascunho de resposta ao usuário (prompt 3).
-
-    Args:
-        result: Dict retornado por analyze_issue().
-        llm_analysis: Texto da análise do LLM (prompt 2).
-        llm: Backend LLM.
-        llm_model: Nome do modelo.
-        llm_url: Endpoint da API.
-        llm_key: API key.
-
-    Returns:
-        Texto do rascunho de resposta ou None.
-    """
-    response_prompt = build_response_prompt(result, llm_analysis)
+def run_response(result: dict, llm_analysis: str, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None, profile: dict | None = None) -> str | None:
+    """Gera relatório técnico para o desenvolvedor (prompt 3)."""
+    response_prompt = build_response_prompt(result, llm_analysis, profile=profile)
     logger.info(f'[LLM] Prompt 3 (resposta ao usuário): {len(response_prompt)} chars → enviando ao {llm} ({llm_model})')
     logger.debug(f'[LLM] Prompt 3 (resposta) conteúdo:\n{response_prompt}')
 

--- a/src/iac/agent/runner.py
+++ b/src/iac/agent/runner.py
@@ -174,7 +174,7 @@ def run_auto(result: dict, structure: dict, graph: dict, base_dir, llm: str, llm
 
     if confidence >= 3:
         logger.info('[auto] Resposta confiante — aceitar single')
-        tipo = extract_tipo_from_analysis(single_analysis)
+        tipo = extract_tipo_from_analysis(single_analysis, profile=profile)
         return {
             'analysis': single_analysis,
             'tipo': tipo,
@@ -241,10 +241,10 @@ def _confidence_score(analysis: str) -> int:
 def run_response(result: dict, llm_analysis: str, llm: str, llm_model: str, llm_url: str | None, llm_key: str | None, profile: dict | None = None) -> str | None:
     """Gera relatório técnico para o desenvolvedor (prompt 3)."""
     response_prompt = build_response_prompt(result, llm_analysis, profile=profile)
-    logger.info(f'[LLM] Prompt 3 (resposta ao usuário): {len(response_prompt)} chars → enviando ao {llm} ({llm_model})')
+    logger.info(f'[LLM] Prompt 3 (relatório técnico): {len(response_prompt)} chars → enviando ao {llm} ({llm_model})')
     logger.debug(f'[LLM] Prompt 3 (resposta) conteúdo:\n{response_prompt}')
 
     response_text = send_to_llm(response_prompt, llm, llm_model, llm_url, llm_key)
-    logger.info(f'[LLM] Resposta 3 (resposta ao usuário): {len(response_text or "")} chars')
+    logger.info(f'[LLM] Resposta 3 (relatório técnico): {len(response_text or "")} chars')
     logger.debug(f'[LLM] Resposta 3 (resposta) conteúdo:\n{response_text}')
     return response_text

--- a/src/iac/analyzer/classifier.py
+++ b/src/iac/analyzer/classifier.py
@@ -3,7 +3,9 @@
 Analisa título, descrição e labels para extrair:
     origem, app, view, url_erro, interessado, erro_id, tipo_sugerido, labels_sugeridos.
 
-Migrado de bin/reviewer/triage/parser.py para o pacote iac.
+Os padrões de issue (regex, field markers, app aliases) são lidos do
+profile (.iac/profile.yaml). Se o profile não define padrões, usa
+detecção genérica por campos comuns.
 """
 
 from __future__ import annotations
@@ -14,19 +16,14 @@ import re
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Regex compilados
+# Regex compilados (genéricos — padrões estruturados comuns)
 # ---------------------------------------------------------------------------
 
-# Título: "Erro XXXX - Nome do App"
-_RE_ERRO_SUAP = re.compile(r'^Erro\s+(\d+)\s*[-\u2013\u2014]\s*(.+)$', re.IGNORECASE)
-
-# Campos estruturados da descrição
 _RE_VIEW_FIELD = re.compile(r'\*\*View\*\*:\s*(\S+)')
 _RE_URL_FIELD = re.compile(r'\*\*URL com erro\*\*:\s*(https?://\S+)')
 _RE_SENTRY_FIELD = re.compile(r'\*\*Sentry\*\*:\s*(https?://\S+|None)')
 _RE_INTERESSADO = re.compile(r'\*\*Interessado principal\*\*:\s*(.+?)(?:\n|$)')
-_RE_DESCRICAO = re.compile(r'\*\*Descrição\*\*:\s*(.+?)(?:\n\*\*|\n\n|$)', re.DOTALL)
-_RE_ERRO_SUAP_LINK = re.compile(r'\*\*Erro no Suap\*\*:\s*(https?://\S+)')
+_RE_DESCRICAO = re.compile(r'\*\*Descri[çc][aã]o\*\*:\s*(.+?)(?:\n\*\*|\n\n|$)', re.DOTALL)
 
 # Exceções de traceback no título (padrão Sentry)
 _RE_EXCEPTION_TITLE = re.compile(
@@ -36,51 +33,24 @@ _RE_EXCEPTION_TITLE = re.compile(
     r'[:\s]',
 )
 
-# Mapeamento de nomes de app no título para labels
-_APP_ALIASES: dict[str, str] = {
-    'Central de Serviços': 'centralservicos',
-    'Centralservicos': 'centralservicos',
-    'Estágios': 'estagios',
-    'Estagios': 'estagios',
-    'Ensino': 'edu',
-    'Eventos': 'eventos',
-    'Auditoria': 'auditoria',
-    'Programa de Gestão 2': 'pgd2',
-    'Programa de Gestão': 'pgd2',
-    'PGD': 'pgd2',
-    'Progressão Docente': 'progressao_docente',
-    'Processos Seletivos': 'processo_seletivo',
-    'Processo Seletivo': 'processo_seletivo',
-    'Comum': 'comum',
-    'Enquetes': 'enquete',
-    'Enquete': 'enquete',
-    'Avaliação Integrada': 'avaliacao_integrada',
-    'Ponto': 'ponto',
-    'Documento Eletrônico': 'documento_eletronico',
-    'Processo Eletrônico': 'processo_eletronico',
-    'RH': 'rh',
-    'Pesquisa': 'pesquisa',
-    'Extensão': 'extensao',
-    'Patrimônio': 'patrimonio',
-    'Almoxarifado': 'almoxarifado',
-    'Contratos': 'contratos',
-    'Saúde': 'saude',
-}
 
-
-def classify(title: str, description: str, labels: list[str] | None = None) -> dict:
+def classify(title: str, description: str, labels: list[str] | None = None, profile: dict | None = None) -> dict:
     """Classifica um incidente a partir do título, descrição e labels.
 
     Args:
         title: Título da issue.
         description: Descrição completa da issue.
         labels: Labels já aplicados à issue, se houver.
+        profile: Perfil do cliente (.iac/profile.yaml) com padrões de issue.
 
     Returns:
         Dict com origem, app, view, url_erro, interessado, erro_id,
         descricao_usuario, sentry_url, traceback, tipo_sugerido e labels_sugeridos.
     """
     labels = labels or []
+    profile = profile or {}
+    patterns = profile.get('issue_patterns', {})
+
     result = {
         'origem': None,
         'app': None,
@@ -95,9 +65,9 @@ def classify(title: str, description: str, labels: list[str] | None = None) -> d
         'labels_sugeridos': [],
     }
 
-    _detectar_origem(title, description, labels, result)
-    _extrair_campos_estruturados(description, result)
-    _extrair_app(title, description, result)
+    _detectar_origem(title, description, labels, result, patterns)
+    _extrair_campos_estruturados(description, result, patterns)
+    _extrair_app(title, description, result, profile)
     _extrair_traceback(description, result)
     _montar_labels(result)
 
@@ -108,14 +78,8 @@ def classify(title: str, description: str, labels: list[str] | None = None) -> d
     return result
 
 
-# ---------------------------------------------------------------------------
-# Detecção de origem
-# ---------------------------------------------------------------------------
-
-
-def _detectar_origem(title: str, description: str, labels: list[str], result: dict) -> None:
-    """Detecta se a issue veio do sistema de erros SUAP, Sentry ou reporte manual."""
-    # Sentry: label 'sentry' ou exceção no título
+def _detectar_origem(title: str, description: str, labels: list[str], result: dict, patterns: dict) -> None:
+    """Detecta se a issue veio do sistema de erros, Sentry ou reporte manual."""
     if 'sentry' in [label.lower() for label in labels]:
         result['origem'] = 'sentry'
         result['tipo_sugerido'] = 'tipo::bug'
@@ -126,72 +90,67 @@ def _detectar_origem(title: str, description: str, labels: list[str], result: di
         result['tipo_sugerido'] = 'tipo::bug'
         return
 
-    # Erro SUAP: título no formato "Erro XXXX - App"
-    match = _RE_ERRO_SUAP.match(title)
+    # Padrão de título configurável (ex: "Erro XXXX - App")
+    title_pattern = patterns.get('title_regex', r'^Erro\s+(\d+)\s*[-\u2013\u2014]\s*(.+)$')
+    match = re.match(title_pattern, title, re.IGNORECASE)
     if match:
-        result['origem'] = 'erro-suap'
+        result['origem'] = patterns.get('origin_name', 'erro-sistema')
         result['erro_id'] = match.group(1)
         return
 
-    # Descrição com campos estruturados do sistema de erros
-    if '**Erro no Suap**:' in description or '**View**:' in description:
-        result['origem'] = 'erro-suap'
+    # Campo marcador na descrição (ex: "**Erro no Suap**:")
+    origin_marker = patterns.get('origin_marker')
+    if origin_marker and origin_marker in description:
+        result['origem'] = patterns.get('origin_name', 'erro-sistema')
+        return
+
+    # Detecção genérica por campos estruturados
+    if '**View**:' in description:
+        result['origem'] = patterns.get('origin_name', 'erro-sistema')
         return
 
     result['origem'] = 'reporte-manual'
 
 
-# ---------------------------------------------------------------------------
-# Extração de campos estruturados
-# ---------------------------------------------------------------------------
-
-
-def _extrair_campos_estruturados(description: str, result: dict) -> None:
+def _extrair_campos_estruturados(description: str, result: dict, patterns: dict) -> None:
     """Extrai campos da descrição estruturada da issue."""
-    # View
     match = _RE_VIEW_FIELD.search(description)
     if match:
         result['view'] = match.group(1)
 
-    # URL com erro
     match = _RE_URL_FIELD.search(description)
     if match:
         result['url_erro'] = match.group(1)
 
-    # Interessado principal
     match = _RE_INTERESSADO.search(description)
     if match:
         result['interessado'] = match.group(1).strip()
 
-    # Descrição do usuário
     match = _RE_DESCRICAO.search(description)
     if match:
         result['descricao_usuario'] = match.group(1).strip()
 
-    # Sentry URL
     match = _RE_SENTRY_FIELD.search(description)
     if match and match.group(1) != 'None':
         result['sentry_url'] = match.group(1)
 
-    # Link do erro SUAP
-    match = _RE_ERRO_SUAP_LINK.search(description)
-    if match and not result['erro_id']:
-        id_match = re.search(r'/erro/(\d+)/', match.group(1))
-        if id_match:
+    # Link do erro (ex: /erro/XXXX/)
+    error_link_pattern = patterns.get('error_link_regex', r'/erro/(\d+)/')
+    for url_match in re.finditer(r'https?://\S+', description):
+        id_match = re.search(error_link_pattern, url_match.group())
+        if id_match and not result['erro_id']:
             result['erro_id'] = id_match.group(1)
+            break
 
 
-# ---------------------------------------------------------------------------
-# Extração de app
-# ---------------------------------------------------------------------------
+def _extrair_app(title: str, description: str, result: dict, profile: dict) -> None:
+    """Extrai o app do framework a partir da view, título ou URL."""
+    patterns = profile.get('issue_patterns', {})
+    app_aliases = profile.get('app_aliases', {})
+    skip_segments = set(profile.get('url_skip_segments', ['admin', 'api', 'static', 'media', 'accounts']))
 
-
-def _extrair_app(title: str, description: str, result: dict) -> None:
-    """Extrai o app Django da view, do título ou da URL."""
     # 1. Da view (mais confiável)
     if result['view']:
-        # admin.comum.comum_registronotificacao_changelist → comum
-        # centralservicos.views.visualizar_chamado → centralservicos
         parts = result['view'].split('.')
         if parts[0] == 'admin' and len(parts) >= 2:
             result['app'] = parts[1]
@@ -199,66 +158,44 @@ def _extrair_app(title: str, description: str, result: dict) -> None:
             result['app'] = parts[0]
         return
 
-    # 2. Do título "Erro XXXX - Nome do App"
-    match = _RE_ERRO_SUAP.match(title)
-    if match:
+    # 2. Do título via app_aliases do profile
+    title_pattern = patterns.get('title_regex', r'^Erro\s+(\d+)\s*[-\u2013\u2014]\s*(.+)$')
+    match = re.match(title_pattern, title, re.IGNORECASE)
+    if match and len(match.groups()) >= 2:
         app_name = match.group(2).strip()
-        for alias, app_label in _APP_ALIASES.items():
+        for alias, app_label in app_aliases.items():
             if alias.lower() == app_name.lower():
                 result['app'] = app_label
                 return
 
-    # 3. Da URL com erro
+    # 3. Da URL
     if result['url_erro']:
         path_match = re.search(r'https?://[^/]+/([^/]+)/', result['url_erro'])
         if path_match:
             segment = path_match.group(1)
-            if segment not in ('admin', 'djtools', 'accounts', 'api', 'static', 'media'):
+            if segment not in skip_segments:
                 result['app'] = segment
                 return
 
-    # 4. Dos labels
-    for label in _APP_ALIASES.values():
-        if label in [lbl.lower() for lbl in (result.get('_labels_raw') or [])]:
-            result['app'] = label
-            return
-
-
-# ---------------------------------------------------------------------------
-# Extração de traceback
-# ---------------------------------------------------------------------------
-
 
 def _extrair_traceback(description: str, result: dict) -> None:
-    """Extrai traceback/stacktrace da descrição (formato Sentry ou bloco de código)."""
-    # Bloco de código com traceback
+    """Extrai traceback/stacktrace da descrição."""
     match = re.search(r'```\s*\n(.+?)```', description, re.DOTALL)
     if match:
         result['traceback'] = match.group(1).strip()
         return
 
-    # Traceback inline (File "..." no texto)
     frames = re.findall(r'File\s+"[^"]+",\s*line\s+\d+,\s*in\s+\w+', description)
     if frames:
         result['traceback'] = '\n'.join(frames)
 
 
-# ---------------------------------------------------------------------------
-# Montagem de labels
-# ---------------------------------------------------------------------------
-
-
 def _montar_labels(result: dict) -> None:
-    """Monta a lista de labels a aplicar com base nos metadados extraídos."""
+    """Monta a lista de labels com base nos metadados extraídos."""
     labels = []
 
-    origem_labels = {
-        'erro-suap': 'origem::erro-suap',
-        'sentry': 'origem::sentry',
-        'reporte-manual': 'origem::reporte-manual',
-    }
-    if result['origem'] and result['origem'] in origem_labels:
-        labels.append(origem_labels[result['origem']])
+    if result['origem']:
+        labels.append(f'origem::{result["origem"]}')
 
     if result['app']:
         labels.append(result['app'])

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -52,21 +52,19 @@ def _generate_default_artifacts(iac_dir: Path, result: dict) -> None:
     """Gera artefatos de configuração padrão se não existem."""
     framework = result.get('framework', 'Python')
 
-    # .env
+    # .env — copiar template completo
     env_file = iac_dir / '.env'
     if not env_file.exists():
-        env_file.write_text(
-            '# IAC — Variáveis de ambiente\n'
-            '# Preencha e descomente conforme necessário\n'
-            '# Ref: .env.example no repositório do IAC\n\n'
-            '# GITLAB_TOKEN=\n'
-            '# IAC_LLM_BACKEND=groq\n'
-            '# IAC_LLM_MODEL=llama-3.3-70b-versatile\n'
-            '# GROQ_API_KEY=\n'
-            '# IAC_ANALYZE_MODE=multi\n'
-            '# IAC_LLM_RATE_DELAY=30\n',
-            encoding='utf-8',
-        )
+        from iac.config.settings import get_defaults_dir
+
+        env_template = get_defaults_dir() / 'env.template'
+        if env_template.exists():
+            content = env_template.read_text(encoding='utf-8')
+            content = content.replace(
+                'Copie este arquivo para .iac/.env no projeto inspecionado e preencha os valores.',
+                f'Configuração do projeto {iac_dir.parent.name}. Descomente e preencha.',
+            )
+            env_file.write_text(content, encoding='utf-8')
         click.echo('  → .iac/.env (template de configuração)')
 
     # profile.yaml — template limpo (sem defaults preenchidos)

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -276,6 +276,7 @@ def analyze(
         graph=graph,
         base_dir=base,
         model_name=llm_model,
+        profile=profile,
     )
 
     # 3. Exibir análise estrutural

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -121,7 +121,7 @@ def analyze(
     # FileHandler em .iac/logs/ — cada execução em arquivo separado
     from datetime import datetime
 
-    from iac.config.settings import get_effective_config, load_graph, load_structure
+    from iac.config.settings import get_effective_config, load_graph, load_profile, load_structure
     log_dir = iac_dir / 'logs'
     log_dir.mkdir(parents=True, exist_ok=True)
     log_filename = f'iac_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
@@ -141,7 +141,9 @@ def analyze(
         'gitlab_token': gitlab_token, 'mode': mode,
     })
 
-    # Resolução: CLI args (já com envvar via click) → config.yaml → defaults
+    profile = load_profile(iac_dir)
+
+    # Resolução: CLI args (já com envvar via click) → .env → defaults
     llm = llm or cfg['llm'].get('backend')
     llm_model = llm_model or cfg['llm'].get('model') or 'qwen2.5:7b'
     llm_url = llm_url or cfg['llm'].get('url')
@@ -244,13 +246,13 @@ def analyze(
 
     if llm and effective_mode == 'auto':
         click.echo(f'\n[Modo auto] Single como fast-path + loop se incerto ({llm} {llm_model})...')
-        loop_result = run_auto(result, structure, graph, base, llm, llm_model, llm_url, llm_key)
+        loop_result = run_auto(result, structure, graph, base, llm, llm_model, llm_url, llm_key, profile=profile)
         mode_used = loop_result.get('mode_used', '?')
         click.echo(f'[auto] Modo usado: {mode_used}')
 
     elif llm and effective_mode == 'loop':
         click.echo(f'\n[Modo loop] Análise interativa com {llm} ({llm_model})...')
-        loop_result = run_loop(result, structure, graph, base, llm, llm_model, llm_url, llm_key)
+        loop_result = run_loop(result, structure, graph, base, llm, llm_model, llm_url, llm_key, profile=profile)
         llm_analysis = loop_result.get('analysis')
         if loop_result.get('alteracoes'):
             click.echo(f'\n--- Alterações de código sugeridas ({len(loop_result["alteracoes"])}) ---\n')
@@ -260,11 +262,11 @@ def analyze(
 
     elif llm and effective_mode == 'multi':
         click.echo(f'\n[Modo multi-prompt] Enviando ao {llm} ({llm_model})...')
-        llm_analysis = run_multi(result, structure, graph, base, llm, llm_model, llm_url, llm_key)
+        llm_analysis = run_multi(result, structure, graph, base, llm, llm_model, llm_url, llm_key, profile=profile)
 
     elif llm:
         click.echo(f'\nEnviando prompt ao {llm} ({llm_model})...')
-        llm_analysis = run_single(result, llm, llm_model, llm_url, llm_key)
+        llm_analysis = run_single(result, llm, llm_model, llm_url, llm_key, profile=profile)
 
     if llm_analysis:
         click.echo('\n--- Análise do LLM ---\n')
@@ -289,7 +291,7 @@ def analyze(
 
         if result['classification'].get('interessado') and tipo:
             click.echo('\nGerando relatório técnico...')
-            response_text = run_response(result, llm_analysis, llm, llm_model, llm_url, llm_key)
+            response_text = run_response(result, llm_analysis, llm, llm_model, llm_url, llm_key, profile=profile)
             if response_text:
                 click.echo('\n--- Relatório técnico ---\n')
                 click.echo(response_text)

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -54,6 +54,12 @@ _BACKEND_KEY_ENV = {
     'gemini': 'GEMINI_API_KEY',
 }
 
+_BACKEND_URL_ENV = {
+    'groq': 'GROQ_API_URL',
+    'deepseek': 'DEEPSEEK_API_URL',
+    'gemini': 'GEMINI_API_URL',
+}
+
 
 def _resolve_api_key(backend: str | None) -> str | None:
     """Resolve API key pela variável de ambiente do backend específico."""
@@ -161,7 +167,7 @@ def init(base_dir: str, force: bool, stats: bool):
 @click.option('--description', type=str, default=None, help='Descrição do incidente.')
 @click.option('--base-dir', type=click.Path(exists=True), default='.', help='Diretório raiz do projeto.')
 @click.option('--llm', type=click.Choice(['ollama', 'groq', 'deepseek', 'gemini']), envvar='IAC_LLM_BACKEND', default=None, help='Backend LLM (env: IAC_LLM_BACKEND).')
-@click.option('--llm-url', type=str, envvar='IAC_LLM_URL', default=None, help='Endpoint do LLM (env: IAC_LLM_URL).')
+@click.option('--llm-url', type=str, envvar='IAC_LLM_URL', default=None, help='Endpoint do LLM (env: IAC_LLM_URL; backends remotos também aceitam *_API_URL específicos).')
 @click.option('--llm-key', type=str, default=None, help='API key do LLM (env: GROQ_API_KEY, GEMINI_API_KEY).')
 @click.option('--llm-model', type=str, envvar='IAC_LLM_MODEL', default=None, help='Modelo do LLM (env: IAC_LLM_MODEL).')
 @click.option('--gitlab-token', type=str, envvar='GITLAB_TOKEN', default=None, help='Token GitLab (env: GITLAB_TOKEN).')
@@ -275,10 +281,16 @@ def analyze(
         sys.exit(1)
 
     # URL default por backend (se não informado)
+    backend_url = os.environ.get(_BACKEND_URL_ENV.get(llm, '')) if llm else None
+    if backend_url:
+        llm_url = backend_url
+
     if llm == 'groq' and (not llm_url or 'localhost' in llm_url):
         llm_url = 'https://api.groq.com/openai/v1/chat/completions'
     elif llm == 'deepseek' and (not llm_url or 'localhost' in llm_url):
         llm_url = 'https://api.deepseek.com/v1/chat/completions'
+    elif llm == 'gemini' and (not llm_url or 'localhost' in llm_url):
+        llm_url = f'https://generativelanguage.googleapis.com/v1beta/models/{llm_model}:generateContent'
 
     logger.info('=== iac analyze iniciado ===')
     logger.info(f'Base dir: {base}')

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -48,6 +48,57 @@ def main(verbose: bool):
     logging.getLogger('gitlab').setLevel(logging.WARNING)
 
 
+def _generate_default_artifacts(iac_dir: Path, result: dict) -> None:
+    """Gera artefatos de configuração padrão se não existem."""
+    framework = result.get('framework', 'Python')
+
+    # .env
+    env_file = iac_dir / '.env'
+    if not env_file.exists():
+        env_file.write_text(
+            '# IAC — Variáveis de ambiente\n'
+            '# Preencha e descomente conforme necessário\n'
+            '# Ref: .env.example no repositório do IAC\n\n'
+            '# GITLAB_TOKEN=\n'
+            '# IAC_LLM_BACKEND=groq\n'
+            '# IAC_LLM_MODEL=llama-3.3-70b-versatile\n'
+            '# GROQ_API_KEY=\n'
+            '# IAC_ANALYZE_MODE=multi\n'
+            '# IAC_LLM_RATE_DELAY=30\n',
+            encoding='utf-8',
+        )
+        click.echo('  → .iac/.env (template de configuração)')
+
+    # profile.yaml
+    profile_file = iac_dir / 'profile.yaml'
+    if not profile_file.exists():
+        import yaml
+
+        profile = {
+            'name': iac_dir.parent.name,
+            'system_description': f'{framework}',
+            'rules': [],
+        }
+        with open(profile_file, 'w', encoding='utf-8') as f:
+            yaml.dump(profile, f, default_flow_style=False, allow_unicode=True)
+        click.echo(f'  → .iac/profile.yaml (perfil do projeto: {framework})')
+
+    # logs/
+    log_dir = iac_dir / 'logs'
+    log_dir.mkdir(exist_ok=True)
+
+    # diagrams/
+    diagrams_dir = iac_dir / 'diagrams'
+    if not diagrams_dir.exists():
+        try:
+            from iac.diagram.generator import generate_diagrams
+
+            generate_diagrams(iac_dir)
+            click.echo('  → .iac/diagrams/ (visualizações interativas)')
+        except Exception as e:
+            logging.getLogger(__name__).debug(f'Diagramas não gerados: {e}')
+
+
 @main.command()
 @click.option('--base-dir', type=click.Path(exists=True), default='.', help='Diretório raiz do projeto.')
 @click.option('--force', is_flag=True, help='Re-inspecionar do zero.')
@@ -75,6 +126,9 @@ def init(base_dir: str, force: bool, stats: bool):
     click.echo(f'Inspecionando {base}...')
     result = inspect_project(base, force=force)
     click.echo(f'Inspeção concluída: {result["summary"]}')
+
+    # Gerar artefatos de configuração se não existem
+    _generate_default_artifacts(iac_dir, result)
 
 
 @main.command()

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -297,12 +297,15 @@ def analyze(
 
         logger.info(f'[Resultado] Classificação: tipo={tipo}, subtipo={subtipo}, labels={result["classification"].get("labels_sugeridos", [])}')
 
-        if result['classification'].get('interessado'):
-            click.echo('\nGerando resposta ao usuário...')
+        if result['classification'].get('interessado') and tipo:
+            click.echo('\nGerando relatório técnico...')
             response_text = run_response(result, llm_analysis, llm, llm_model, llm_url, llm_key)
             if response_text:
-                click.echo('\n--- Rascunho de resposta ---\n')
+                click.echo('\n--- Relatório técnico ---\n')
                 click.echo(response_text)
+        elif not tipo:
+            logger.warning('[LLM] Classificação inconclusiva — relatório técnico não gerado')
+            click.echo('\nClassificação inconclusiva — relatório técnico não gerado.')
     elif llm:
         logger.warning('[LLM] Nenhuma resposta do LLM')
         click.echo('LLM não retornou resposta.')

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -69,16 +69,17 @@ def _generate_default_artifacts(iac_dir: Path, result: dict) -> None:
         )
         click.echo('  → .iac/.env (template de configuração)')
 
-    # profile.yaml — copiar do template de defaults
+    # profile.yaml — copiar template e personalizar com nome e framework
     profile_file = iac_dir / 'profile.yaml'
     if not profile_file.exists():
-        import shutil
-
         from iac.config.settings import get_defaults_dir
 
         default_profile = get_defaults_dir() / 'profile.yaml'
         if default_profile.exists():
-            shutil.copy(default_profile, profile_file)
+            content = default_profile.read_text(encoding='utf-8')
+            content = content.replace('name: ""', f'name: "{iac_dir.parent.name}"')
+            content = content.replace('system_description: "Django"', f'system_description: "{framework}"')
+            profile_file.write_text(content, encoding='utf-8')
         else:
             import yaml
             yaml.dump({'name': iac_dir.parent.name, 'system_description': framework, 'rules': []}, open(profile_file, 'w', encoding='utf-8'), default_flow_style=False, allow_unicode=True)  # noqa: SIM115

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -48,6 +48,21 @@ def main(verbose: bool):
     logging.getLogger('gitlab').setLevel(logging.WARNING)
 
 
+_BACKEND_KEY_ENV = {
+    'groq': 'GROQ_API_KEY',
+    'deepseek': 'DEEPSEEK_API_KEY',
+    'gemini': 'GEMINI_API_KEY',
+}
+
+
+def _resolve_api_key(backend: str | None) -> str | None:
+    """Resolve API key pela variável de ambiente do backend específico."""
+    if backend and backend in _BACKEND_KEY_ENV:
+        return os.environ.get(_BACKEND_KEY_ENV[backend])
+    # Fallback: tentar todas
+    return os.environ.get('GROQ_API_KEY') or os.environ.get('DEEPSEEK_API_KEY') or os.environ.get('GEMINI_API_KEY')
+
+
 def _generate_default_artifacts(iac_dir: Path, result: dict) -> None:
     """Gera artefatos de configuração padrão se não existem."""
     framework = result.get('framework', 'Python')
@@ -210,7 +225,7 @@ def analyze(
     llm = llm or cfg['llm'].get('backend')
     llm_model = llm_model or cfg['llm'].get('model') or 'qwen2.5:7b'
     llm_url = llm_url or cfg['llm'].get('url')
-    llm_key = llm_key or cfg['llm'].get('key') or os.environ.get('GROQ_API_KEY') or os.environ.get('DEEPSEEK_API_KEY') or os.environ.get('GEMINI_API_KEY')
+    llm_key = llm_key or cfg['llm'].get('key') or _resolve_api_key(llm)
     gitlab_token = gitlab_token or cfg['gitlab'].get('token') or os.environ.get('GITLAB_TOKEN')
     mode = mode or cfg['analyze'].get('mode') or 'auto'
 

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -69,19 +69,20 @@ def _generate_default_artifacts(iac_dir: Path, result: dict) -> None:
         )
         click.echo('  → .iac/.env (template de configuração)')
 
-    # profile.yaml
+    # profile.yaml — copiar do template de defaults
     profile_file = iac_dir / 'profile.yaml'
     if not profile_file.exists():
-        import yaml
+        import shutil
 
-        profile = {
-            'name': iac_dir.parent.name,
-            'system_description': f'{framework}',
-            'rules': [],
-        }
-        with open(profile_file, 'w', encoding='utf-8') as f:
-            yaml.dump(profile, f, default_flow_style=False, allow_unicode=True)
-        click.echo(f'  → .iac/profile.yaml (perfil do projeto: {framework})')
+        from iac.config.settings import get_defaults_dir
+
+        default_profile = get_defaults_dir() / 'profile.yaml'
+        if default_profile.exists():
+            shutil.copy(default_profile, profile_file)
+        else:
+            import yaml
+            yaml.dump({'name': iac_dir.parent.name, 'system_description': framework, 'rules': []}, open(profile_file, 'w', encoding='utf-8'), default_flow_style=False, allow_unicode=True)  # noqa: SIM115
+        click.echo('  → .iac/profile.yaml (perfil do projeto — customize para seu sistema)')
 
     # logs/
     log_dir = iac_dir / 'logs'

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -69,20 +69,17 @@ def _generate_default_artifacts(iac_dir: Path, result: dict) -> None:
         )
         click.echo('  → .iac/.env (template de configuração)')
 
-    # profile.yaml — copiar template e personalizar com nome e framework
+    # profile.yaml — template limpo (sem defaults preenchidos)
     profile_file = iac_dir / 'profile.yaml'
     if not profile_file.exists():
         from iac.config.settings import get_defaults_dir
 
-        default_profile = get_defaults_dir() / 'profile.yaml'
-        if default_profile.exists():
-            content = default_profile.read_text(encoding='utf-8')
+        init_template = get_defaults_dir() / 'profile.init.yaml'
+        if init_template.exists():
+            content = init_template.read_text(encoding='utf-8')
             content = content.replace('name: ""', f'name: "{iac_dir.parent.name}"')
             content = content.replace('system_description: "Django"', f'system_description: "{framework}"')
             profile_file.write_text(content, encoding='utf-8')
-        else:
-            import yaml
-            yaml.dump({'name': iac_dir.parent.name, 'system_description': framework, 'rules': []}, open(profile_file, 'w', encoding='utf-8'), default_flow_style=False, allow_unicode=True)  # noqa: SIM115
         click.echo('  → .iac/profile.yaml (perfil do projeto — customize para seu sistema)')
 
     # logs/

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -86,16 +86,28 @@ def _generate_default_artifacts(iac_dir: Path, result: dict) -> None:
     log_dir = iac_dir / 'logs'
     log_dir.mkdir(exist_ok=True)
 
-    # diagrams/
-    diagrams_dir = iac_dir / 'diagrams'
-    if not diagrams_dir.exists():
-        try:
-            from iac.diagram.generator import generate_diagrams
+    # diagrams/ — overview + detalhe por app
+    try:
+        from iac.config.settings import load_structure
+        from iac.diagram.generator import generate_app_detail_data, generate_overview_data, write_html
 
-            generate_diagrams(iac_dir)
-            click.echo('  → .iac/diagrams/ (visualizações interativas)')
-        except Exception as e:
-            logging.getLogger(__name__).debug(f'Diagramas não gerados: {e}')
+        diagrams_dir = iac_dir / 'diagrams'
+        count = 0
+
+        data = generate_overview_data(iac_dir)
+        write_html(diagrams_dir / 'overview.html', 'overview.html', data)
+        count += 1
+
+        structure = load_structure(iac_dir)
+        for app_name in structure.get('apps', {}):
+            app_data = generate_app_detail_data(iac_dir, app_name)
+            if app_data['nodes']:
+                write_html(diagrams_dir / f'{app_name}.html', 'app_detail.html', app_data)
+                count += 1
+
+        click.echo(f'  → .iac/diagrams/ ({count} visualizações interativas)')
+    except Exception as e:
+        logging.getLogger(__name__).debug(f'Diagramas não gerados: {e}')
 
 
 @main.command()

--- a/src/iac/cli.py
+++ b/src/iac/cli.py
@@ -111,16 +111,6 @@ def analyze(
         click.echo('Informe --issue-url, --title ou --description.')
         sys.exit(1)
 
-    # Carregar .env se informado via --env-file
-    if env_file:
-        from dotenv import load_dotenv
-        env_path = Path(env_file)
-        if env_path.exists():
-            load_dotenv(env_path, override=False)
-        else:
-            click.echo(f'Arquivo .env não encontrado: {env_file}')
-            sys.exit(1)
-
     base = Path(base_dir).resolve()
     iac_dir = base / IAC_DIR
 
@@ -145,7 +135,7 @@ def analyze(
     from iac.agent.orchestrator import analyze_issue, format_structural_analysis
     from iac.agent.prompts import extract_classificacao
 
-    # Configuração efetiva: config.yaml + CLI args
+    # Configuração efetiva: .env + CLI args
     cfg = get_effective_config(iac_dir, {
         'llm': llm, 'llm_model': llm_model, 'llm_url': llm_url, 'llm_key': llm_key,
         'gitlab_token': gitlab_token, 'mode': mode,
@@ -177,7 +167,7 @@ def analyze(
         gitlab_url_parsed, project_path, issue_id = parsed
         token = gitlab_token
         if not token:
-            click.echo('Token GitLab necessário. Use --gitlab-token, GITLAB_TOKEN ou config.yaml.')
+            click.echo('Token GitLab necessário. Use --gitlab-token, GITLAB_TOKEN ou .iac/.env.')
             sys.exit(1)
 
         click.echo(f'Buscando issue {issue_id} no GitLab...')
@@ -337,7 +327,7 @@ def analyze(
 @click.option('--set', 'set_values', multiple=True, help='Definir valor: seção.chave=valor (ex: llm.model=qwen2.5-coder:7b)')
 @click.option('--show', is_flag=True, help='Exibir configuração atual.')
 def config_cmd(base_dir: str, set_values: tuple, show: bool):
-    """Gerencia configuração do projeto (.iac/config.yaml)."""
+    """Gerencia configuração do projeto (.iac/.env)."""
     base = Path(base_dir).resolve()
     iac_dir = base / IAC_DIR
 
@@ -345,31 +335,37 @@ def config_cmd(base_dir: str, set_values: tuple, show: bool):
         click.echo('Nenhuma inspeção encontrada. Execute `iac init` primeiro.')
         sys.exit(1)
 
-    from iac.config.settings import load_user_config, save_user_config
+    from iac.config.settings import get_effective_config
 
-    config = load_user_config(iac_dir)
+    env_file = iac_dir / '.env'
 
     if set_values:
+        lines = env_file.read_text(encoding='utf-8').splitlines() if env_file.exists() else []
         for item in set_values:
             if '=' not in item:
-                click.echo(f'Formato inválido: {item}. Use seção.chave=valor')
+                click.echo(f'Formato inválido: {item}. Use CHAVE=valor')
                 continue
             key, value = item.split('=', 1)
-            parts = key.split('.')
-            if len(parts) == 2:
-                section, field = parts
-                if section not in config:
-                    config[section] = {}
-                config[section][field] = value
-                click.echo(f'{section}.{field} = {value}')
-            else:
-                click.echo(f'Formato inválido: {item}. Use seção.chave=valor')
-
-        save_user_config(iac_dir, config)
+            key = key.upper()
+            # Atualizar ou adicionar
+            updated = False
+            for i, line in enumerate(lines):
+                if line.startswith((f'{key}=', f'# {key}=')):
+                    lines[i] = f'{key}={value}'
+                    updated = True
+                    break
+            if not updated:
+                lines.append(f'{key}={value}')
+            click.echo(f'{key}={value}')
+        env_file.write_text('\n'.join(lines) + '\n', encoding='utf-8')
 
     if show or not set_values:
-        import yaml
-        click.echo(yaml.dump(config, default_flow_style=False, allow_unicode=True))
+        config = get_effective_config(iac_dir, {})
+        for section, values in config.items():
+            if isinstance(values, dict):
+                for k, v in values.items():
+                    if v is not None:
+                        click.echo(f'{section}.{k} = {v}')
 
 
 @main.command()

--- a/src/iac/config/app_settings.py
+++ b/src/iac/config/app_settings.py
@@ -3,7 +3,7 @@
 Princípio 1 — Explícito sobre Implícito:
 todas as configurações tipadas, com defaults explícitos e validação.
 
-Hierarquia: defaults → config.yaml → variáveis de ambiente → CLI args.
+Hierarquia: defaults → .env → variáveis de ambiente → CLI args.
 
 Variáveis de ambiente aceitas:
     GROQ_API_KEY     — API key do Groq (gratuito)

--- a/src/iac/config/app_settings.py
+++ b/src/iac/config/app_settings.py
@@ -28,7 +28,11 @@ from pydantic_settings import BaseSettings
 
 
 def _resolve_llm_key() -> str | None:
-    """Resolve API key pela ordem: GROQ_API_KEY → DEEPSEEK_API_KEY → GEMINI_API_KEY → IAC_LLM_KEY."""
+    """Resolve API key pelo backend configurado, ou fallback genérico."""
+    backend = os.environ.get('IAC_LLM_BACKEND', '')
+    backend_keys = {'groq': 'GROQ_API_KEY', 'deepseek': 'DEEPSEEK_API_KEY', 'gemini': 'GEMINI_API_KEY'}
+    if backend in backend_keys:
+        return os.environ.get(backend_keys[backend]) or os.environ.get('IAC_LLM_KEY')
     return os.environ.get('GROQ_API_KEY') or os.environ.get('DEEPSEEK_API_KEY') or os.environ.get('GEMINI_API_KEY') or os.environ.get('IAC_LLM_KEY')
 
 

--- a/src/iac/config/app_settings.py
+++ b/src/iac/config/app_settings.py
@@ -9,7 +9,7 @@ Variáveis de ambiente aceitas:
     GITLAB_TOKEN        — Access token do GitLab
     IAC_LLM_BACKEND     — Backend LLM (ollama, groq, deepseek, gemini)
     IAC_LLM_MODEL       — Nome do modelo
-    IAC_LLM_URL         — Endpoint da API
+    IAC_LLM_URL         — Endpoint genérico (fallback)
     IAC_LLM_KEY         — API key genérica (fallback)
     IAC_LLM_RATE_DELAY  — Delay entre chamadas em segundos (0 = sem delay)
     IAC_LLM_MAX_RETRIES — Máximo de retries em rate limit (default: 3)
@@ -17,6 +17,9 @@ Variáveis de ambiente aceitas:
     GROQ_API_KEY        — API key do Groq
     DEEPSEEK_API_KEY    — API key do DeepSeek
     GEMINI_API_KEY      — API key do Google Gemini
+    GROQ_API_URL        — Endpoint do Groq (opcional)
+    DEEPSEEK_API_URL    — Endpoint do DeepSeek (opcional)
+    GEMINI_API_URL      — Endpoint do Gemini (opcional)
 """
 
 from __future__ import annotations
@@ -36,6 +39,21 @@ def _resolve_llm_key() -> str | None:
     return os.environ.get('GROQ_API_KEY') or os.environ.get('DEEPSEEK_API_KEY') or os.environ.get('GEMINI_API_KEY') or os.environ.get('IAC_LLM_KEY')
 
 
+def _resolve_llm_url() -> str:
+    """Resolve endpoint pelo backend configurado, com fallback genérico."""
+    backend = os.environ.get('IAC_LLM_BACKEND', '')
+    backend_urls = {
+        'groq': 'GROQ_API_URL',
+        'deepseek': 'DEEPSEEK_API_URL',
+        'gemini': 'GEMINI_API_URL',
+    }
+    if backend in backend_urls:
+        value = os.environ.get(backend_urls[backend])
+        if value:
+            return value
+    return os.environ.get('IAC_LLM_URL', 'http://localhost:11434/v1/chat/completions')
+
+
 def _resolve_gitlab_token() -> str | None:
     """Resolve token pela ordem: GITLAB_TOKEN → IAC_GITLAB_TOKEN."""
     return os.environ.get('GITLAB_TOKEN') or os.environ.get('IAC_GITLAB_TOKEN')
@@ -46,7 +64,7 @@ class LLMSettings(BaseSettings):
 
     backend: str = Field('ollama', description='Backend: ollama | groq | deepseek | gemini')
     model: str = Field('qwen2.5:7b', description='Nome do modelo')
-    url: str = Field('http://localhost:11434/v1/chat/completions', description='Endpoint da API')
+    url: str = Field(default_factory=_resolve_llm_url, description='Endpoint da API')
     key: str | None = Field(default_factory=_resolve_llm_key, description='API key (GROQ_API_KEY, DEEPSEEK_API_KEY, GEMINI_API_KEY ou IAC_LLM_KEY)')
     max_tokens: int = Field(4000, description='Máximo de tokens na resposta')
     temperature: float = Field(0.2, description='Temperatura do modelo')

--- a/src/iac/config/app_settings.py
+++ b/src/iac/config/app_settings.py
@@ -6,13 +6,17 @@ todas as configurações tipadas, com defaults explícitos e validação.
 Hierarquia: defaults → .env → variáveis de ambiente → CLI args.
 
 Variáveis de ambiente aceitas:
-    GROQ_API_KEY     — API key do Groq (gratuito)
-    GITLAB_TOKEN     — Access token do GitLab
-    GEMINI_API_KEY   — API key do Google Gemini
-    IAC_LLM_BACKEND  — Backend LLM (ollama, groq, gemini)
-    IAC_LLM_MODEL    — Nome do modelo
-    IAC_LLM_URL      — Endpoint da API
-    IAC_LLM_KEY      — API key genérica (fallback)
+    GITLAB_TOKEN        — Access token do GitLab
+    IAC_LLM_BACKEND     — Backend LLM (ollama, groq, deepseek, gemini)
+    IAC_LLM_MODEL       — Nome do modelo
+    IAC_LLM_URL         — Endpoint da API
+    IAC_LLM_KEY         — API key genérica (fallback)
+    IAC_LLM_RATE_DELAY  — Delay entre chamadas em segundos (0 = sem delay)
+    IAC_LLM_MAX_RETRIES — Máximo de retries em rate limit (default: 3)
+    IAC_ANALYZE_MODE    — Modo de análise (auto, single, multi, loop)
+    GROQ_API_KEY        — API key do Groq
+    DEEPSEEK_API_KEY    — API key do DeepSeek
+    GEMINI_API_KEY      — API key do Google Gemini
 """
 
 from __future__ import annotations
@@ -36,13 +40,15 @@ def _resolve_gitlab_token() -> str | None:
 class LLMSettings(BaseSettings):
     """Configurações do backend LLM."""
 
-    backend: str = Field('ollama', description='Backend: ollama | groq | gemini')
+    backend: str = Field('ollama', description='Backend: ollama | groq | deepseek | gemini')
     model: str = Field('qwen2.5:7b', description='Nome do modelo')
     url: str = Field('http://localhost:11434/v1/chat/completions', description='Endpoint da API')
-    key: str | None = Field(default_factory=_resolve_llm_key, description='API key (GROQ_API_KEY, GEMINI_API_KEY ou IAC_LLM_KEY)')
+    key: str | None = Field(default_factory=_resolve_llm_key, description='API key (GROQ_API_KEY, DEEPSEEK_API_KEY, GEMINI_API_KEY ou IAC_LLM_KEY)')
     max_tokens: int = Field(4000, description='Máximo de tokens na resposta')
     temperature: float = Field(0.2, description='Temperatura do modelo')
     timeout: int = Field(1200, description='Timeout em segundos')
+    rate_delay: int = Field(0, description='Delay entre chamadas em segundos (0 = sem delay)')
+    max_retries: int = Field(3, description='Máximo de retries em rate limit')
 
     model_config = {'env_prefix': 'IAC_LLM_'}
 

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -260,10 +260,20 @@ def get_effective_config(iac_dir: Path, cli_args: dict) -> dict:
     config = dict(DEFAULT_CONFIG)
 
     # .env → os.environ → config (só se não None)
+    backend_url = (
+        os.environ.get('GROQ_API_URL')
+        if os.environ.get('IAC_LLM_BACKEND') == 'groq' else
+        os.environ.get('DEEPSEEK_API_URL')
+        if os.environ.get('IAC_LLM_BACKEND') == 'deepseek' else
+        os.environ.get('GEMINI_API_URL')
+        if os.environ.get('IAC_LLM_BACKEND') == 'gemini' else
+        None
+    )
+
     env_map = {
         ('llm', 'backend'): os.environ.get('IAC_LLM_BACKEND'),
         ('llm', 'model'): os.environ.get('IAC_LLM_MODEL'),
-        ('llm', 'url'): os.environ.get('IAC_LLM_URL'),
+        ('llm', 'url'): backend_url or os.environ.get('IAC_LLM_URL'),
         ('llm', 'key'): os.environ.get('GROQ_API_KEY') or os.environ.get('DEEPSEEK_API_KEY') or os.environ.get('GEMINI_API_KEY'),
         ('gitlab', 'token'): os.environ.get('GITLAB_TOKEN'),
         ('analyze', 'mode'): os.environ.get('IAC_ANALYZE_MODE'),

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -115,6 +115,41 @@ def save_graph(iac_dir: Path, graph: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# profile.yaml — perfil do cliente (padrões de issue, regras, taxonomia)
+# ---------------------------------------------------------------------------
+
+PROFILE_FILE = 'profile.yaml'
+
+DEFAULT_PROFILE = {
+    'system_description': 'Django',
+    'rules': [],
+}
+
+
+def load_profile(iac_dir: Path) -> dict:
+    """Carrega profile.yaml do .iac/. Retorna defaults se não existir.
+
+    Args:
+        iac_dir: Caminho para o diretório .iac do projeto.
+
+    Returns:
+        Dict com system_description e rules.
+    """
+    import yaml
+
+    profile_file = iac_dir / PROFILE_FILE
+    if not profile_file.exists():
+        return dict(DEFAULT_PROFILE)
+
+    with open(profile_file, encoding='utf-8') as f:
+        profile = yaml.safe_load(f) or {}
+
+    merged = dict(DEFAULT_PROFILE)
+    merged.update(profile)
+    return merged
+
+
+# ---------------------------------------------------------------------------
 # .env — configuração via variáveis de ambiente
 # ---------------------------------------------------------------------------
 

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -205,9 +205,12 @@ def _merge_profiles(defaults: dict, project: dict) -> dict:
         'name': project.get('name') or defaults.get('name', ''),
         'system_description': project.get('system_description') or defaults.get('system_description', 'Django'),
         'rules': project.get('rules') if project.get('rules') is not None else defaults.get('rules', []),
+        'issue_patterns': {**defaults.get('issue_patterns', {}), **project.get('issue_patterns', {})},
+        'app_aliases': {**defaults.get('app_aliases', {}), **project.get('app_aliases', {})},
+        'url_skip_segments': list(set(defaults.get('url_skip_segments', [])) | set(project.get('url_skip_segments', []))),
     }
 
-    # Taxonomia: merge
+    # Taxonomia: merge (união de known_tipos, merge de aliases)
     def_tax = defaults.get('taxonomy', {})
     proj_tax = project.get('taxonomy', {})
 

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -166,43 +166,60 @@ def get_defaults_dir() -> Path:
 
 
 def load_profile(iac_dir: Path) -> dict:
-    """Carrega profile.yaml do .iac/. Retorna defaults se não existir.
+    """Carrega defaults + profile do projeto com merge.
 
-    Fallback: src/iac/defaults/profile.yaml.
+    Hierarquia: defaults/profile.yaml → .iac/profile.yaml (projeto sobrescreve/amplia).
     """
     import yaml
 
+    # 1. Carregar defaults
+    default_file = get_defaults_dir() / PROFILE_FILE
+    if default_file.exists():
+        with open(default_file, encoding='utf-8') as f:
+            defaults = yaml.safe_load(f) or {}
+    else:
+        defaults = {}
+
+    # 2. Carregar profile do projeto
     profile_file = iac_dir / PROFILE_FILE
-    if not profile_file.exists():
-        # Tentar carregar defaults do pacote
-        default_file = get_defaults_dir() / PROFILE_FILE
-        if default_file.exists():
-            with open(default_file, encoding='utf-8') as f:
-                return _build_profile(yaml.safe_load(f) or {})
-        return _build_profile({})
+    if profile_file.exists():
+        with open(profile_file, encoding='utf-8') as f:
+            project = yaml.safe_load(f) or {}
+    else:
+        project = {}
 
-    with open(profile_file, encoding='utf-8') as f:
-        profile = yaml.safe_load(f) or {}
-
-    return _build_profile(profile)
+    # 3. Merge: defaults + projeto
+    return _merge_profiles(defaults, project)
 
 
-def _build_profile(raw: dict) -> dict:
-    """Constrói profile completo com defaults para campos ausentes."""
+def _merge_profiles(defaults: dict, project: dict) -> dict:
+    """Merge de defaults + profile do projeto.
+
+    Regras:
+    - system_description: projeto sobrescreve default
+    - rules: projeto sobrescreve (lista inteira)
+    - taxonomy.known_tipos: união (default + projeto)
+    - taxonomy.aliases: merge (default + projeto, projeto tem prioridade)
+    """
     profile = {
-        'name': raw.get('name', ''),
-        'system_description': raw.get('system_description', 'Django'),
-        'rules': raw.get('rules', []),
+        'name': project.get('name') or defaults.get('name', ''),
+        'system_description': project.get('system_description') or defaults.get('system_description', 'Django'),
+        'rules': project.get('rules') if project.get('rules') is not None else defaults.get('rules', []),
     }
 
-    # Taxonomia: merge com defaults
-    taxonomy = raw.get('taxonomy', {})
-    known = taxonomy.get('known_tipos')
-    aliases = taxonomy.get('aliases')
+    # Taxonomia: merge
+    def_tax = defaults.get('taxonomy', {})
+    proj_tax = project.get('taxonomy', {})
+
+    def_known = set(def_tax.get('known_tipos', DEFAULT_KNOWN_TIPOS))
+    proj_known = set(proj_tax.get('known_tipos', []))
+
+    def_aliases = dict(def_tax.get('aliases', DEFAULT_ALIASES))
+    proj_aliases = dict(proj_tax.get('aliases', {}))
 
     profile['taxonomy'] = {
-        'known_tipos': set(known) if known else set(DEFAULT_KNOWN_TIPOS),
-        'aliases': dict(aliases) if aliases else dict(DEFAULT_ALIASES),
+        'known_tipos': def_known | proj_known,
+        'aliases': {**def_aliases, **proj_aliases},
     }
 
     return profile

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -6,16 +6,12 @@ import json
 import logging
 from pathlib import Path
 
-import yaml
-
 logger = logging.getLogger(__name__)
 
 IAC_DIR = '.iac'
 PROJECT_FILE = 'project.json'
 STRUCTURE_FILE = 'structure.json'
 GRAPH_FILE = 'graph.json'
-CONFIG_FILE = 'config.yaml'
-
 DEFAULT_CONFIG = {
     'llm': {
         'backend': 'ollama',
@@ -119,121 +115,73 @@ def save_graph(iac_dir: Path, graph: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
-# config.yaml — configurações persistentes do projeto
+# .env — configuração via variáveis de ambiente
 # ---------------------------------------------------------------------------
 
 
-def _load_dotenv(iac_dir: Path, user_config: dict) -> None:
-    """Carrega .env se configurado ou se existir no .iac/.
+def load_dotenv(iac_dir: Path, env_file: str | None = None) -> None:
+    """Carrega .env do .iac/ ou de caminho customizado.
 
-    Prioridade: config.yaml (env_file) → .iac/.env → argumento --env-file.
+    Args:
+        iac_dir: Caminho para o diretório .iac do projeto.
+        env_file: Caminho customizado para .env (override).
     """
-    from dotenv import load_dotenv
+    from dotenv import load_dotenv as _load_dotenv
 
-    env_path = user_config.get('env_file')
-    if env_path:
-        env_file = Path(env_path)
-        if not env_file.is_absolute():
-            env_file = iac_dir / env_file
+    if env_file:
+        path = Path(env_file)
+        if not path.is_absolute():
+            path = iac_dir / path
     else:
-        env_file = iac_dir / '.env'
+        path = iac_dir / '.env'
 
-    if env_file.exists():
-        load_dotenv(env_file, override=False)
-        logger.info(f'Variáveis carregadas de {env_file}')
-
-
-def load_user_config(iac_dir: Path) -> dict:
-    """Carrega config.yaml do .iac/. Retorna defaults se não existir.
-
-    Também carrega .env se existir em .iac/.env ou no caminho
-    configurado em config.yaml (env_file: caminho/para/.env).
-
-    Args:
-        iac_dir: Caminho para o diretório .iac do projeto.
-
-    Returns:
-        Dict com configuração efetiva (defaults + valores do usuário mesclados).
-    """
-    config_file = iac_dir / CONFIG_FILE
-    if not config_file.exists():
-        _load_dotenv(iac_dir, {})
-        return dict(DEFAULT_CONFIG)
-
-    with open(config_file, encoding='utf-8') as f:
-        user_config = yaml.safe_load(f) or {}
-
-    _load_dotenv(iac_dir, user_config)
-
-    # Merge com defaults (user sobrescreve)
-    merged = dict(DEFAULT_CONFIG)
-    for section, defaults in DEFAULT_CONFIG.items():
-        if section in user_config and isinstance(defaults, dict):
-            merged[section] = {**defaults, **user_config[section]}
-        elif section in user_config:
-            merged[section] = user_config[section]
-
-    return merged
-
-
-def save_user_config(iac_dir: Path, config: dict) -> None:
-    """Salva config.yaml no .iac/.
-
-    Args:
-        iac_dir: Caminho para o diretório .iac do projeto.
-        config: Dict de configuração a persistir (valores None são omitidos).
-    """
-    iac_dir.mkdir(parents=True, exist_ok=True)
-    config_file = iac_dir / CONFIG_FILE
-
-    # Remover valores None para config limpo
-    clean = {}
-    for section, values in config.items():
-        if isinstance(values, dict):
-            filtered = {k: v for k, v in values.items() if v is not None}
-            if filtered:
-                clean[section] = filtered
-        elif values is not None:
-            clean[section] = values
-
-    with open(config_file, 'w', encoding='utf-8') as f:
-        yaml.dump(clean, f, default_flow_style=False, allow_unicode=True)
-    logger.info(f'Configuração salva em {config_file}')
+    if path.exists():
+        _load_dotenv(path, override=False)
+        logger.info(f'Variáveis carregadas de {path}')
 
 
 def get_effective_config(iac_dir: Path, cli_args: dict) -> dict:
-    """Retorna configuração efetiva: config.yaml + overrides do CLI.
+    """Retorna configuração efetiva: defaults + .env + CLI args.
 
-    CLI args sobrescrevem config.yaml que sobrescreve defaults.
+    Hierarquia: DEFAULT_CONFIG → .env (via os.environ) → CLI args.
 
     Args:
         iac_dir: Caminho para o diretório .iac do projeto.
-        cli_args: Dict com args do CLI (llm, llm_model, llm_url, llm_key, gitlab_token, mode).
+        cli_args: Dict com args do CLI.
 
     Returns:
-        Dict de configuração com seções llm, gitlab e analyze já mescladas.
+        Dict de configuração com seções llm, gitlab e analyze.
     """
-    config = load_user_config(iac_dir)
+    import os
 
-    # Mapear CLI args para seções do config
-    overrides = {
-        'llm': {
-            'backend': cli_args.get('llm'),
-            'model': cli_args.get('llm_model'),
-            'url': cli_args.get('llm_url'),
-            'key': cli_args.get('llm_key'),
-        },
-        'gitlab': {
-            'token': cli_args.get('gitlab_token'),
-        },
-        'analyze': {
-            'mode': cli_args.get('mode'),
-        },
+    load_dotenv(iac_dir)
+
+    config = dict(DEFAULT_CONFIG)
+
+    # .env → os.environ → config (só se não None)
+    env_map = {
+        ('llm', 'backend'): os.environ.get('IAC_LLM_BACKEND'),
+        ('llm', 'model'): os.environ.get('IAC_LLM_MODEL'),
+        ('llm', 'url'): os.environ.get('IAC_LLM_URL'),
+        ('llm', 'key'): os.environ.get('GROQ_API_KEY') or os.environ.get('DEEPSEEK_API_KEY') or os.environ.get('GEMINI_API_KEY'),
+        ('gitlab', 'token'): os.environ.get('GITLAB_TOKEN'),
+        ('analyze', 'mode'): os.environ.get('IAC_ANALYZE_MODE'),
     }
+    for (section, key), value in env_map.items():
+        if value:
+            config[section][key] = value
 
-    for section, values in overrides.items():
-        for key, value in values.items():
-            if value is not None:
-                config[section][key] = value
+    # CLI args (maior prioridade)
+    overrides = {
+        ('llm', 'backend'): cli_args.get('llm'),
+        ('llm', 'model'): cli_args.get('llm_model'),
+        ('llm', 'url'): cli_args.get('llm_url'),
+        ('llm', 'key'): cli_args.get('llm_key'),
+        ('gitlab', 'token'): cli_args.get('gitlab_token'),
+        ('analyze', 'mode'): cli_args.get('mode'),
+    }
+    for (section, key), value in overrides.items():
+        if value is not None:
+            config[section][key] = value
 
     return config

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -120,33 +120,92 @@ def save_graph(iac_dir: Path, graph: dict) -> None:
 
 PROFILE_FILE = 'profile.yaml'
 
+DEFAULT_KNOWN_TIPOS = {
+    'tipo::bug',
+    'tipo::configuracao',
+    'tipo::dados-cadastrais',
+    'tipo::prazo-expirado',
+    'tipo::nao-e-erro',
+    'tipo::permissao',
+}
+
+DEFAULT_ALIASES = {
+    'tipo::avaliacao-nao-disponivel': 'tipo::prazo-expirado',
+    'tipo::prazo-avaliacao': 'tipo::prazo-expirado',
+    'tipo::tempo-expirado': 'tipo::prazo-expirado',
+    'tipo::tempo-esgotado': 'tipo::prazo-expirado',
+    'tipo::tempo-de-execucao-insuficiente': 'tipo::prazo-expirado',
+    'tipo::tempo-insuficiente-para-avaliacao': 'tipo::prazo-expirado',
+    'tipo::tempo-habil-para-avaliacao': 'tipo::prazo-expirado',
+    'tipo::tempo-de-avaliacao-expirado': 'tipo::prazo-expirado',
+    'tipo::tempo-de-avaliacao-insuficiente': 'tipo::prazo-expirado',
+    'tipo::validacao-falhada': 'tipo::bug',
+    'tipo::logica-incorreta': 'tipo::bug',
+    'tipo::excecao-nao-tratada': 'tipo::bug',
+    'tipo::erro-de-codigo': 'tipo::bug',
+    'tipo::erro-de-negocio': 'tipo::bug',
+    'tipo::comportamento-esperado': 'tipo::nao-e-erro',
+    'tipo::filtro-avaliacoes': 'tipo::nao-e-erro',
+    'tipo::acesso-negado': 'tipo::permissao',
+    'tipo::sem-permissao': 'tipo::permissao',
+}
+
 DEFAULT_PROFILE = {
     'system_description': 'Django',
     'rules': [],
+    'taxonomy': {
+        'known_tipos': list(DEFAULT_KNOWN_TIPOS),
+        'aliases': dict(DEFAULT_ALIASES),
+    },
 }
+
+
+def get_defaults_dir() -> Path:
+    """Retorna o diretório de defaults do IAC."""
+    return Path(__file__).parent.parent / 'defaults'
 
 
 def load_profile(iac_dir: Path) -> dict:
     """Carrega profile.yaml do .iac/. Retorna defaults se não existir.
 
-    Args:
-        iac_dir: Caminho para o diretório .iac do projeto.
-
-    Returns:
-        Dict com system_description e rules.
+    Fallback: src/iac/defaults/profile.yaml.
     """
     import yaml
 
     profile_file = iac_dir / PROFILE_FILE
     if not profile_file.exists():
-        return dict(DEFAULT_PROFILE)
+        # Tentar carregar defaults do pacote
+        default_file = get_defaults_dir() / PROFILE_FILE
+        if default_file.exists():
+            with open(default_file, encoding='utf-8') as f:
+                return _build_profile(yaml.safe_load(f) or {})
+        return _build_profile({})
 
     with open(profile_file, encoding='utf-8') as f:
         profile = yaml.safe_load(f) or {}
 
-    merged = dict(DEFAULT_PROFILE)
-    merged.update(profile)
-    return merged
+    return _build_profile(profile)
+
+
+def _build_profile(raw: dict) -> dict:
+    """Constrói profile completo com defaults para campos ausentes."""
+    profile = {
+        'name': raw.get('name', ''),
+        'system_description': raw.get('system_description', 'Django'),
+        'rules': raw.get('rules', []),
+    }
+
+    # Taxonomia: merge com defaults
+    taxonomy = raw.get('taxonomy', {})
+    known = taxonomy.get('known_tipos')
+    aliases = taxonomy.get('aliases')
+
+    profile['taxonomy'] = {
+        'known_tipos': set(known) if known else set(DEFAULT_KNOWN_TIPOS),
+        'aliases': dict(aliases) if aliases else dict(DEFAULT_ALIASES),
+    }
+
+    return profile
 
 
 # ---------------------------------------------------------------------------

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -120,46 +120,27 @@ def save_graph(iac_dir: Path, graph: dict) -> None:
 
 PROFILE_FILE = 'profile.yaml'
 
-DEFAULT_KNOWN_TIPOS = {
-    'tipo::bug',
-    'tipo::configuracao',
-    'tipo::dados-cadastrais',
-    'tipo::prazo-expirado',
-    'tipo::nao-e-erro',
-    'tipo::permissao',
-}
 
-DEFAULT_ALIASES = {
-    # prazo-expirado
-    'tipo::avaliacao-nao-disponivel': 'tipo::prazo-expirado',
-    'tipo::prazo-avaliacao': 'tipo::prazo-expirado',
-    'tipo::prazo-insuficiente': 'tipo::prazo-expirado',
-    'tipo::tempo-expirado': 'tipo::prazo-expirado',
-    'tipo::tempo-esgotado': 'tipo::prazo-expirado',
-    'tipo::tempo-de-execucao-insuficiente': 'tipo::prazo-expirado',
-    'tipo::tempo-insuficiente-para-avaliacao': 'tipo::prazo-expirado',
-    'tipo::tempo-habil-para-avaliacao': 'tipo::prazo-expirado',
-    'tipo::tempo-de-avaliacao-expirado': 'tipo::prazo-expirado',
-    'tipo::tempo-de-avaliacao-insuficiente': 'tipo::prazo-expirado',
-    'tipo::avaliacao-tempo-habil-insuficiente': 'tipo::prazo-expirado',
-    'tipo::erro-de-temporizacao': 'tipo::prazo-expirado',
-    'tipo::avaliacao-nao-realizada': 'tipo::prazo-expirado',
-    # bug
-    'tipo::validacao-falhada': 'tipo::bug',
-    'tipo::logica-incorreta': 'tipo::bug',
-    'tipo::excecao-nao-tratada': 'tipo::bug',
-    'tipo::erro-de-codigo': 'tipo::bug',
-    'tipo::erro-de-negocio': 'tipo::bug',
-    'tipo::erro-de-logica': 'tipo::bug',
-    # nao-e-erro
-    'tipo::comportamento-esperado': 'tipo::nao-e-erro',
-    'tipo::filtro-avaliacoes': 'tipo::nao-e-erro',
-    # permissao
-    'tipo::acesso-negado': 'tipo::permissao',
-    'tipo::sem-permissao': 'tipo::permissao',
-    'tipo::acesso-inesperado': 'tipo::permissao',
-    'tipo::permissao-insuficiente': 'tipo::permissao',
-}
+def get_defaults_dir() -> Path:
+    """Retorna o diretório de defaults do IAC."""
+    return Path(__file__).parent.parent / 'defaults'
+
+
+def _load_default_taxonomy() -> tuple[set, dict]:
+    """Carrega known_tipos e aliases do defaults/profile.yaml (fonte única)."""
+    import yaml
+
+    default_file = get_defaults_dir() / PROFILE_FILE
+    if default_file.exists():
+        with open(default_file, encoding='utf-8') as f:
+            data = yaml.safe_load(f) or {}
+        tax = data.get('taxonomy', {})
+        return set(tax.get('known_tipos', [])), dict(tax.get('aliases', {}))
+    return set(), {}
+
+
+# Carregados do defaults/profile.yaml — fonte única de verdade
+DEFAULT_KNOWN_TIPOS, DEFAULT_ALIASES = _load_default_taxonomy()
 
 DEFAULT_PROFILE = {
     'system_description': 'Django',
@@ -169,11 +150,6 @@ DEFAULT_PROFILE = {
         'aliases': dict(DEFAULT_ALIASES),
     },
 }
-
-
-def get_defaults_dir() -> Path:
-    """Retorna o diretório de defaults do IAC."""
-    return Path(__file__).parent.parent / 'defaults'
 
 
 def load_profile(iac_dir: Path) -> dict:

--- a/src/iac/config/settings.py
+++ b/src/iac/config/settings.py
@@ -130,8 +130,10 @@ DEFAULT_KNOWN_TIPOS = {
 }
 
 DEFAULT_ALIASES = {
+    # prazo-expirado
     'tipo::avaliacao-nao-disponivel': 'tipo::prazo-expirado',
     'tipo::prazo-avaliacao': 'tipo::prazo-expirado',
+    'tipo::prazo-insuficiente': 'tipo::prazo-expirado',
     'tipo::tempo-expirado': 'tipo::prazo-expirado',
     'tipo::tempo-esgotado': 'tipo::prazo-expirado',
     'tipo::tempo-de-execucao-insuficiente': 'tipo::prazo-expirado',
@@ -139,15 +141,24 @@ DEFAULT_ALIASES = {
     'tipo::tempo-habil-para-avaliacao': 'tipo::prazo-expirado',
     'tipo::tempo-de-avaliacao-expirado': 'tipo::prazo-expirado',
     'tipo::tempo-de-avaliacao-insuficiente': 'tipo::prazo-expirado',
+    'tipo::avaliacao-tempo-habil-insuficiente': 'tipo::prazo-expirado',
+    'tipo::erro-de-temporizacao': 'tipo::prazo-expirado',
+    'tipo::avaliacao-nao-realizada': 'tipo::prazo-expirado',
+    # bug
     'tipo::validacao-falhada': 'tipo::bug',
     'tipo::logica-incorreta': 'tipo::bug',
     'tipo::excecao-nao-tratada': 'tipo::bug',
     'tipo::erro-de-codigo': 'tipo::bug',
     'tipo::erro-de-negocio': 'tipo::bug',
+    'tipo::erro-de-logica': 'tipo::bug',
+    # nao-e-erro
     'tipo::comportamento-esperado': 'tipo::nao-e-erro',
     'tipo::filtro-avaliacoes': 'tipo::nao-e-erro',
+    # permissao
     'tipo::acesso-negado': 'tipo::permissao',
     'tipo::sem-permissao': 'tipo::permissao',
+    'tipo::acesso-inesperado': 'tipo::permissao',
+    'tipo::permissao-insuficiente': 'tipo::permissao',
 }
 
 DEFAULT_PROFILE = {

--- a/src/iac/defaults/__init__.py
+++ b/src/iac/defaults/__init__.py
@@ -1,0 +1,1 @@
+"""Defaults genéricos do IAC — templates copiados pelo iac init."""

--- a/src/iac/defaults/env.template
+++ b/src/iac/defaults/env.template
@@ -19,7 +19,7 @@
 # -----------------------------------------------------------------------------
 # IAC_LLM_BACKEND=groq
 # IAC_LLM_MODEL=llama-3.3-70b-versatile
-# IAC_LLM_URL=
+# IAC_LLM_URL=   # fallback genérico; prefira *_API_URL por backend
 # IAC_LLM_KEY=
 
 # -----------------------------------------------------------------------------
@@ -34,18 +34,21 @@
 # qwen/qwen3-32b, meta-llama/llama-4-scout-17b-16e-instruct
 # -----------------------------------------------------------------------------
 # GROQ_API_KEY=gsk_...
+# GROQ_API_URL=https://api.groq.com/openai/v1/chat/completions
 
 # -----------------------------------------------------------------------------
 # DeepSeek (https://platform.deepseek.com/api_keys)
 # $5 grátis. Modelos: deepseek-coder, deepseek-chat, deepseek-reasoner
 # -----------------------------------------------------------------------------
 # DEEPSEEK_API_KEY=sk-...
+# DEEPSEEK_API_URL=https://api.deepseek.com/v1/chat/completions
 
 # -----------------------------------------------------------------------------
 # Gemini (https://aistudio.google.com/apikey)
 # 50 req/dia grátis. Modelos: gemini-2.5-pro, gemini-2.0-flash
 # -----------------------------------------------------------------------------
 # GEMINI_API_KEY=AIza...
+# GEMINI_API_URL=https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
 
 # -----------------------------------------------------------------------------
 # Análise

--- a/src/iac/defaults/env.template
+++ b/src/iac/defaults/env.template
@@ -1,0 +1,53 @@
+# =============================================================================
+# IAC — Variáveis de ambiente (.env.example)
+# =============================================================================
+# Copie este arquivo para .iac/.env no projeto inspecionado e preencha os valores.
+# Hierarquia: .env → variáveis de ambiente → CLI args (CLI tem prioridade)
+#
+# Uso:
+#   cp .env.example /caminho/projeto/.iac/.env
+#   # editar e preencher valores
+#   iac analyze --base-dir /caminho/projeto --issue-url URL
+
+# -----------------------------------------------------------------------------
+# GitLab
+# -----------------------------------------------------------------------------
+# GITLAB_TOKEN=glpat-...
+
+# -----------------------------------------------------------------------------
+# LLM Backend (ollama | groq | deepseek | gemini)
+# -----------------------------------------------------------------------------
+# IAC_LLM_BACKEND=groq
+# IAC_LLM_MODEL=llama-3.3-70b-versatile
+# IAC_LLM_URL=
+# IAC_LLM_KEY=
+
+# -----------------------------------------------------------------------------
+# Rate limit (genérico — aplica para qualquer backend remoto)
+# -----------------------------------------------------------------------------
+# IAC_LLM_RATE_DELAY=30
+# IAC_LLM_MAX_RETRIES=3
+
+# -----------------------------------------------------------------------------
+# Groq (https://console.groq.com/keys)
+# Gratuito com rate limit. Modelos: llama-3.3-70b-versatile, llama-3.1-8b-instant,
+# qwen/qwen3-32b, meta-llama/llama-4-scout-17b-16e-instruct
+# -----------------------------------------------------------------------------
+# GROQ_API_KEY=gsk_...
+
+# -----------------------------------------------------------------------------
+# DeepSeek (https://platform.deepseek.com/api_keys)
+# $5 grátis. Modelos: deepseek-coder, deepseek-chat, deepseek-reasoner
+# -----------------------------------------------------------------------------
+# DEEPSEEK_API_KEY=sk-...
+
+# -----------------------------------------------------------------------------
+# Gemini (https://aistudio.google.com/apikey)
+# 50 req/dia grátis. Modelos: gemini-2.5-pro, gemini-2.0-flash
+# -----------------------------------------------------------------------------
+# GEMINI_API_KEY=AIza...
+
+# -----------------------------------------------------------------------------
+# Análise
+# -----------------------------------------------------------------------------
+# IAC_ANALYZE_MODE=multi

--- a/src/iac/defaults/profile.init.yaml
+++ b/src/iac/defaults/profile.init.yaml
@@ -1,0 +1,82 @@
+# =============================================================================
+# IAC — Perfil do projeto (.iac/profile.yaml)
+# =============================================================================
+# Este arquivo configura o IAC para o seu projeto.
+# Gerado pelo `iac init`. Customize conforme o seu sistema.
+#
+# Seções não definidas aqui usam os defaults genéricos do IAC.
+# Documentação: docs/ARCHITECTURE.md
+
+# -----------------------------------------------------------------------------
+# Identificação
+# -----------------------------------------------------------------------------
+# Nome do projeto e descrição usada nos prompts do LLM.
+name: ""
+system_description: "Django"
+
+# -----------------------------------------------------------------------------
+# Padrões de template de issue
+# -----------------------------------------------------------------------------
+# Defina como o seu sistema gera issues de erro.
+# Se não configurar, usa detecção genérica por campos comuns (**View**:, etc).
+#
+# Exemplo:
+#   issue_patterns:
+#     title_regex: '^Erro\s+(\d+)\s*[-\u2013\u2014]\s*(.+)$'
+#     origin_name: "erro-sistema"
+#     origin_marker: "**Erro no Sistema**:"
+#     error_link_regex: '/erro/(\d+)/'
+issue_patterns: {}
+
+# -----------------------------------------------------------------------------
+# Mapeamento de apps
+# -----------------------------------------------------------------------------
+# Nomes legíveis no título da issue → nome do app no código.
+# Usado quando a view não é informada na issue.
+#
+# Exemplo:
+#   app_aliases:
+#     Central de Serviços: centralservicos
+#     Ensino: edu
+app_aliases: {}
+
+# -----------------------------------------------------------------------------
+# Segmentos de URL a ignorar
+# -----------------------------------------------------------------------------
+# Ao detectar app pela URL, esses segmentos são ignorados.
+# Os defaults do IAC já incluem: admin, api, static, media, accounts.
+# Adicione aqui apenas os específicos do seu projeto.
+#
+# Exemplo:
+#   url_skip_segments:
+#     - djtools
+#     - internal
+url_skip_segments: []
+
+# -----------------------------------------------------------------------------
+# Heurísticas de domínio
+# -----------------------------------------------------------------------------
+# Regras injetadas nos prompts do LLM. Adapte ao seu domínio.
+# Ajudam o LLM a priorizar hipóteses corretas.
+#
+# Exemplo:
+#   rules:
+#     - "Se o interessado é Aluno, não assuma erro de permissão sem evidência"
+#     - "Se a descrição menciona 'prazo', priorize constantes temporais"
+rules: []
+
+# -----------------------------------------------------------------------------
+# Taxonomia
+# -----------------------------------------------------------------------------
+# Labels conhecidos e aliases para normalização de classificação.
+# Os defaults do IAC já incluem: bug, configuracao, dados-cadastrais,
+# prazo-expirado, nao-e-erro, permissao (e 18 aliases).
+# Adicione aqui apenas os específicos do seu projeto.
+#
+# Exemplo:
+#   taxonomy:
+#     known_tipos:
+#       - tipo::custom-label
+#     aliases:
+#       tipo::meu-alias: tipo::bug
+taxonomy: {}

--- a/src/iac/defaults/profile.yaml
+++ b/src/iac/defaults/profile.yaml
@@ -75,9 +75,10 @@ taxonomy:
 
   # Labels criativos do LLM → label conhecido mais próximo
   aliases:
-    # prazo-expirado
+    # prazo-expirado (variantes temporais)
     tipo::avaliacao-nao-disponivel: tipo::prazo-expirado
     tipo::prazo-avaliacao: tipo::prazo-expirado
+    tipo::prazo-insuficiente: tipo::prazo-expirado
     tipo::tempo-expirado: tipo::prazo-expirado
     tipo::tempo-esgotado: tipo::prazo-expirado
     tipo::tempo-de-execucao-insuficiente: tipo::prazo-expirado
@@ -85,15 +86,21 @@ taxonomy:
     tipo::tempo-habil-para-avaliacao: tipo::prazo-expirado
     tipo::tempo-de-avaliacao-expirado: tipo::prazo-expirado
     tipo::tempo-de-avaliacao-insuficiente: tipo::prazo-expirado
-    # bug
+    tipo::avaliacao-tempo-habil-insuficiente: tipo::prazo-expirado
+    tipo::erro-de-temporizacao: tipo::prazo-expirado
+    tipo::avaliacao-nao-realizada: tipo::prazo-expirado
+    # bug (variantes de erro de código)
     tipo::validacao-falhada: tipo::bug
     tipo::logica-incorreta: tipo::bug
     tipo::excecao-nao-tratada: tipo::bug
     tipo::erro-de-codigo: tipo::bug
     tipo::erro-de-negocio: tipo::bug
+    tipo::erro-de-logica: tipo::bug
     # nao-e-erro
     tipo::comportamento-esperado: tipo::nao-e-erro
     tipo::filtro-avaliacoes: tipo::nao-e-erro
-    # permissao
+    # permissao (variantes de acesso)
     tipo::acesso-negado: tipo::permissao
     tipo::sem-permissao: tipo::permissao
+    tipo::acesso-inesperado: tipo::permissao
+    tipo::permissao-insuficiente: tipo::permissao

--- a/src/iac/defaults/profile.yaml
+++ b/src/iac/defaults/profile.yaml
@@ -1,22 +1,68 @@
-# IAC — Perfil padrão (genérico)
-# Copie para .iac/profile.yaml do projeto inspecionado e customize.
+# =============================================================================
+# IAC — Perfil do projeto (.iac/profile.yaml)
+# =============================================================================
+# Este arquivo configura o IAC para o projeto inspecionado.
+# Gerado pelo `iac init`. Customize conforme o seu sistema.
 #
 # Seções:
-#   name              — Nome do projeto
-#   system_description — Descrição usada nos prompts do LLM
-#   rules             — Heurísticas de domínio injetadas nos prompts
-#   taxonomy          — Catálogo de tipos + aliases para normalização
+#   name               — Nome do projeto
+#   system_description  — Descrição usada nos prompts do LLM
+#   issue_patterns      — Padrões do template de issue (regex, marcadores)
+#   app_aliases         — Mapeamento de nomes de app no título para labels
+#   url_skip_segments   — Segmentos de URL a ignorar na detecção de app
+#   rules               — Heurísticas de domínio injetadas nos prompts
+#   taxonomy            — Catálogo de tipos + aliases para normalização
 
+# -----------------------------------------------------------------------------
+# Identificação
+# -----------------------------------------------------------------------------
 name: ""
 system_description: "Django"
 
-# Heurísticas de domínio — regras injetadas nos prompts do LLM
-# Exemplos (descomente e adapte ao seu projeto):
+# -----------------------------------------------------------------------------
+# Padrões de template de issue
+# -----------------------------------------------------------------------------
+# Defina como o seu sistema gera issues de erro.
+# Se não configurar, usa detecção genérica por campos comuns.
+issue_patterns: {}
+  # title_regex: '^Erro\s+(\d+)\s*[-\u2013\u2014]\s*(.+)$'  # Regex do título (grupo 1: ID, grupo 2: app)
+  # origin_name: "erro-sistema"                                # Nome da origem nos labels
+  # origin_marker: "**Erro no Sistema**:"                      # Marcador na descrição
+  # error_link_regex: '/erro/(\d+)/'                           # Regex para extrair ID do link
+
+# -----------------------------------------------------------------------------
+# Mapeamento de apps
+# -----------------------------------------------------------------------------
+# Nomes legíveis no título → nome do app no código.
+# Usado quando a view não é informada na issue.
+app_aliases: {}
+  # Central de Serviços: centralservicos
+  # Ensino: edu
+
+# -----------------------------------------------------------------------------
+# Segmentos de URL a ignorar
+# -----------------------------------------------------------------------------
+# Ao detectar app pela URL, esses segmentos são ignorados.
+url_skip_segments:
+  - admin
+  - api
+  - static
+  - media
+  - accounts
+
+# -----------------------------------------------------------------------------
+# Heurísticas de domínio
+# -----------------------------------------------------------------------------
+# Regras injetadas nos prompts do LLM. Adapte ao seu domínio.
 rules: []
   # - "Se o interessado é Aluno, não assuma erro de permissão sem evidência"
   # - "Se a descrição menciona 'prazo', priorize constantes temporais"
 
-# Taxonomia — tipos conhecidos e aliases para normalização
+# -----------------------------------------------------------------------------
+# Taxonomia
+# -----------------------------------------------------------------------------
+# Labels conhecidos para classificação e aliases para normalização.
+# O IAC faz merge: defaults + o que você definir aqui.
 taxonomy:
   # Labels válidos para classificação
   known_tipos:

--- a/src/iac/defaults/profile.yaml
+++ b/src/iac/defaults/profile.yaml
@@ -1,0 +1,53 @@
+# IAC — Perfil padrão (genérico)
+# Copie para .iac/profile.yaml do projeto inspecionado e customize.
+#
+# Seções:
+#   name              — Nome do projeto
+#   system_description — Descrição usada nos prompts do LLM
+#   rules             — Heurísticas de domínio injetadas nos prompts
+#   taxonomy          — Catálogo de tipos + aliases para normalização
+
+name: ""
+system_description: "Django"
+
+# Heurísticas de domínio — regras injetadas nos prompts do LLM
+# Exemplos (descomente e adapte ao seu projeto):
+rules: []
+  # - "Se o interessado é Aluno, não assuma erro de permissão sem evidência"
+  # - "Se a descrição menciona 'prazo', priorize constantes temporais"
+
+# Taxonomia — tipos conhecidos e aliases para normalização
+taxonomy:
+  # Labels válidos para classificação
+  known_tipos:
+    - tipo::bug
+    - tipo::configuracao
+    - tipo::dados-cadastrais
+    - tipo::prazo-expirado
+    - tipo::nao-e-erro
+    - tipo::permissao
+
+  # Labels criativos do LLM → label conhecido mais próximo
+  aliases:
+    # prazo-expirado
+    tipo::avaliacao-nao-disponivel: tipo::prazo-expirado
+    tipo::prazo-avaliacao: tipo::prazo-expirado
+    tipo::tempo-expirado: tipo::prazo-expirado
+    tipo::tempo-esgotado: tipo::prazo-expirado
+    tipo::tempo-de-execucao-insuficiente: tipo::prazo-expirado
+    tipo::tempo-insuficiente-para-avaliacao: tipo::prazo-expirado
+    tipo::tempo-habil-para-avaliacao: tipo::prazo-expirado
+    tipo::tempo-de-avaliacao-expirado: tipo::prazo-expirado
+    tipo::tempo-de-avaliacao-insuficiente: tipo::prazo-expirado
+    # bug
+    tipo::validacao-falhada: tipo::bug
+    tipo::logica-incorreta: tipo::bug
+    tipo::excecao-nao-tratada: tipo::bug
+    tipo::erro-de-codigo: tipo::bug
+    tipo::erro-de-negocio: tipo::bug
+    # nao-e-erro
+    tipo::comportamento-esperado: tipo::nao-e-erro
+    tipo::filtro-avaliacoes: tipo::nao-e-erro
+    # permissao
+    tipo::acesso-negado: tipo::permissao
+    tipo::sem-permissao: tipo::permissao

--- a/src/iac/integrations/groq.py
+++ b/src/iac/integrations/groq.py
@@ -9,8 +9,8 @@ Retry automático com backoff quando 429 é retornado.
 
 Variáveis de ambiente:
     GROQ_API_KEY       — API key (obrigatória)
-    GROQ_RATE_DELAY    — Delay em segundos entre chamadas (default: 0)
-    GROQ_MAX_RETRIES   — Máximo de retries em rate limit (default: 3)
+    IAC_LLM_RATE_DELAY  — Delay em segundos entre chamadas (genérico, no runner)
+    IAC_LLM_MAX_RETRIES — Máximo de retries em rate limit (default: 3)
 """
 
 from __future__ import annotations

--- a/src/iac/models.py
+++ b/src/iac/models.py
@@ -18,12 +18,12 @@ from pydantic import BaseModel, Field
 class Classification(BaseModel):
     """Metadados extraídos da issue pelo classifier (sem LLM)."""
 
-    origem: str | None = Field(None, description='erro-suap | sentry | reporte-manual')
-    app: str | None = Field(None, description='App Django (ex: centralservicos)')
-    view: str | None = Field(None, description='FQN da view (ex: centralservicos.views.visualizar_chamado)')
+    origem: str | None = Field(None, description='erro-sistema | sentry | reporte-manual')
+    app: str | None = Field(None, description='App do framework (ex: loja)')
+    view: str | None = Field(None, description='FQN da view (ex: loja.views.detalhe_produto)')
     url_erro: str | None = Field(None, description='URL com erro reportada')
     interessado: str | None = Field(None, description='Nome + matrícula do interessado')
-    erro_id: str | None = Field(None, description='ID do erro SUAP (ex: 9645)')
+    erro_id: str | None = Field(None, description='ID do erro no sistema (ex: 9645)')
     descricao_usuario: str | None = Field(None, description='Texto livre do usuário')
     sentry_url: str | None = Field(None, description='URL do Sentry se presente')
     traceback: str | None = Field(None, description='Traceback/stacktrace extraído')

--- a/tests/test_agent/test_loop.py
+++ b/tests/test_agent/test_loop.py
@@ -5,7 +5,12 @@ _request_key, detecção de repetição.
 """
 
 from iac.agent.loop import _detect_action, _request_key
-from iac.agent.prompts.utils import _normalize_label, extract_tipo_from_analysis, normalize_to_known
+from iac.agent.prompts.utils import (
+    _normalize_label,
+    extract_classificacao,
+    extract_tipo_from_analysis,
+    normalize_to_known,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -166,3 +171,52 @@ def test_normalize_known_tipo_not_aliased():
     """Labels já conhecidos não precisam de alias."""
     assert normalize_to_known('tipo::bug') is None
     assert normalize_to_known('tipo::prazo-expirado') is None
+
+
+def test_normalize_tempo_aliases():
+    """Labels temporais criativos devem normalizar para prazo-expirado."""
+    assert normalize_to_known('tipo::tempo-de-execucao-insuficiente') == 'tipo::prazo-expirado'
+    assert normalize_to_known('tipo::tempo-habil-para-avaliacao') == 'tipo::prazo-expirado'
+    assert normalize_to_known('tipo::tempo-de-avaliacao-insuficiente') == 'tipo::prazo-expirado'
+
+
+def test_normalize_comportamento_esperado():
+    assert normalize_to_known('tipo::comportamento-esperado') == 'tipo::nao-e-erro'
+
+
+# ---------------------------------------------------------------------------
+# extract_classificacao — labels sem prefixo tipo:: (#57 melhoria 2)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_bare_label_bug():
+    """CLASSIFICAÇÃO: bug (sem tipo::) deve resolver para tipo::bug."""
+    result = extract_classificacao('CLASSIFICAÇÃO: bug\nSUBCLASSIFICAÇÃO: logica-incorreta')
+    assert result['classificacao'] == 'tipo::bug'
+    assert result['subclassificacao'] == 'tipo::bug'  # logica-incorreta → bug via alias
+
+
+def test_extract_bare_label_nao_e_erro():
+    """CLASSIFICAÇÃO: nao-e-erro → tipo::nao-e-erro."""
+    result = extract_classificacao('CLASSIFICAÇÃO: nao-e-erro')
+    assert result['classificacao'] == 'tipo::nao-e-erro'
+
+
+def test_extract_bare_label_permissao():
+    """CLASSIFICAÇÃO: permissao → tipo::permissao."""
+    result = extract_classificacao('CLASSIFICAÇÃO: permissao')
+    assert result['classificacao'] == 'tipo::permissao'
+
+
+def test_extract_subclassificacao_normalized():
+    """Subclassificação fora do catálogo deve ser normalizada."""
+    result = extract_classificacao('CLASSIFICAÇÃO: tipo::nao-e-erro\nSUBCLASSIFICAÇÃO: tipo::comportamento-esperado')
+    assert result['classificacao'] == 'tipo::nao-e-erro'
+    assert result['subclassificacao'] == 'tipo::nao-e-erro'  # comportamento-esperado → nao-e-erro
+
+
+def test_extract_subclassificacao_prazo():
+    """Subclassificação prazo-expirado ou alias deve normalizar."""
+    result = extract_classificacao('CLASSIFICAÇÃO: tipo::nao-e-erro\nSUBCLASSIFICAÇÃO: tipo::prazo-expirado')
+    assert result['classificacao'] == 'tipo::nao-e-erro'
+    assert result['subclassificacao'] == 'tipo::prazo-expirado'  # já é known, mantém

--- a/tests/test_agent/test_orchestrator.py
+++ b/tests/test_agent/test_orchestrator.py
@@ -215,7 +215,7 @@ def test_structural_analysis_has_components(django_project):
     assert analysis['app'] == 'loja'
     assert analysis['view'] == 'loja.views.detalhe_produto'
     assert analysis['file'] is not None
-    assert analysis['origem'] == 'erro-suap'
+    assert analysis['origem'] == 'erro-sistema'
     assert analysis['erro_id'] == '1234'
     assert 'produto não carrega' in (analysis['descricao_usuario'] or '')
 

--- a/tests/test_analyzer/test_classifier.py
+++ b/tests/test_analyzer/test_classifier.py
@@ -1,17 +1,33 @@
-"""Testes para o classificador de incidentes (analyzer/classifier.py)."""
+"""Testes para o classificador de incidentes (analyzer/classifier.py).
+
+Testes de core (genéricos) + testes com profile SUAP.
+"""
 
 from iac.analyzer.classifier import classify
 
+# Profile SUAP para testes que dependem de padrões específicos
+SUAP_PROFILE = {
+    'issue_patterns': {
+        'title_regex': r'^Erro\s+(\d+)\s*[-\u2013\u2014]\s*(.+)$',
+        'origin_name': 'erro-suap',
+        'origin_marker': '**Erro no Suap**:',
+        'error_link_regex': r'/erro/(\d+)/',
+    },
+    'app_aliases': {
+        'Central de Serviços': 'centralservicos',
+        'Ensino': 'edu',
+        'Eventos': 'eventos',
+        'Progressão Docente': 'progressao_docente',
+        'Comum': 'comum',
+        'Enquetes': 'enquete',
+    },
+    'url_skip_segments': ['admin', 'djtools', 'accounts', 'api', 'static', 'media'],
+}
+
 
 # ---------------------------------------------------------------------------
-# Detecção de origem
+# Core (genérico — sem profile)
 # ---------------------------------------------------------------------------
-
-
-def test_origem_erro_suap():
-    result = classify('Erro 9645 - Progressão Docente', '')
-    assert result['origem'] == 'erro-suap'
-    assert result['erro_id'] == '9645'
 
 
 def test_origem_sentry_label():
@@ -30,104 +46,16 @@ def test_origem_reporte_manual():
     assert result['origem'] == 'reporte-manual'
 
 
-def test_origem_campos_estruturados():
-    result = classify('Título genérico', '**Erro no Suap**: https://suap/erros/1/')
-    assert result['origem'] == 'erro-suap'
-
-
-# ---------------------------------------------------------------------------
-# Extração de campos
-# ---------------------------------------------------------------------------
-
-
-DESCRICAO_COMPLETA = (
-    '**Erro no Suap**: https://suap.ifrn.edu.br/erros/erro/9645/\n\n'
-    '**URL com erro**: https://suap.ifrn.edu.br/progressao_docente/ver_avaliacoes_discente/\n\n'
-    '**Sentry**: None\n\n'
-    '**View**: progressao_docente.views.ver_avaliacoes_discente\n\n'
-    '**Descrição**: não conseguiu visualizar a avaliação em tempo hábil.\n\n'
-    '**Interessado principal**: José Rosinaldo de Luna (20231124120023) (Aluno)\n'
-)
-
-
-def test_extrair_view():
-    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA)
-    assert result['view'] == 'progressao_docente.views.ver_avaliacoes_discente'
-
-
-def test_extrair_url_erro():
-    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA)
-    assert result['url_erro'] == 'https://suap.ifrn.edu.br/progressao_docente/ver_avaliacoes_discente/'
-
-
-def test_extrair_interessado():
-    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA)
-    assert 'José Rosinaldo de Luna' in result['interessado']
-    assert '20231124120023' in result['interessado']
-
-
-def test_extrair_descricao_usuario():
-    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA)
-    assert 'não conseguiu visualizar' in result['descricao_usuario']
-
-
-def test_extrair_erro_id_do_titulo():
-    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA)
-    assert result['erro_id'] == '9645'
-
-
-def test_extrair_erro_id_do_link():
-    desc = '**Erro no Suap**: https://suap.ifrn.edu.br/erros/erro/9999/'
-    result = classify('Título genérico', desc)
-    assert result['erro_id'] == '9999'
-
-
-def test_sentry_url_none():
-    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA)
-    assert result['sentry_url'] is None
-
-
-def test_sentry_url_presente():
-    desc = '**Sentry**: http://sentry.ifrn.edu.br/issues/5762/'
-    result = classify('Erro 9679 - Enquetes', desc)
-    assert result['sentry_url'] == 'http://sentry.ifrn.edu.br/issues/5762/'
-
-
-# ---------------------------------------------------------------------------
-# Extração de app
-# ---------------------------------------------------------------------------
-
-
 def test_app_da_view():
-    result = classify('Erro 9645', DESCRICAO_COMPLETA)
+    desc = '**View**: progressao_docente.views.ver_avaliacoes_discente'
+    result = classify('Erro 9645', desc)
     assert result['app'] == 'progressao_docente'
 
 
 def test_app_da_view_admin():
     desc = '**View**: admin.comum.comum_registronotificacao_changelist'
-    result = classify('Erro 9693 - Comum', desc)
+    result = classify('Erro 9693 - Comum', desc, profile=SUAP_PROFILE)
     assert result['app'] == 'comum'
-
-
-def test_app_do_titulo():
-    result = classify('Erro 9660 - Eventos', '')
-    assert result['app'] == 'eventos'
-
-
-def test_app_do_titulo_alias():
-    result = classify('Erro 9678 - Ensino', '')
-    assert result['app'] == 'edu'
-
-
-def test_app_da_url():
-    desc = '**URL com erro**: https://suap.ifrn.edu.br/enquete/responder/1/'
-    result = classify('Título sem app', desc)
-    assert result['app'] == 'enquete'
-
-
-# ---------------------------------------------------------------------------
-# Extração de traceback
-# ---------------------------------------------------------------------------
 
 
 def test_traceback_bloco_codigo():
@@ -150,18 +78,97 @@ def test_traceback_inline():
     assert 'enquete/views.py' in result['traceback']
 
 
-# ---------------------------------------------------------------------------
-# Labels
-# ---------------------------------------------------------------------------
-
-
-def test_labels_erro_suap():
-    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA)
-    assert 'origem::erro-suap' in result['labels_sugeridos']
-    assert 'progressao_docente' in result['labels_sugeridos']
-
-
 def test_labels_sentry():
     result = classify('ValueError: x', '', labels=['sentry', 'ponto'])
     assert 'origem::sentry' in result['labels_sugeridos']
     assert 'tipo::bug' in result['labels_sugeridos']
+
+
+# ---------------------------------------------------------------------------
+# Com profile SUAP
+# ---------------------------------------------------------------------------
+
+
+def test_origem_erro_suap():
+    result = classify('Erro 9645 - Progressão Docente', '', profile=SUAP_PROFILE)
+    assert result['origem'] == 'erro-suap'
+    assert result['erro_id'] == '9645'
+
+
+def test_origem_campos_estruturados():
+    result = classify('Título genérico', '**Erro no Suap**: https://suap/erros/1/', profile=SUAP_PROFILE)
+    assert result['origem'] == 'erro-suap'
+
+
+DESCRICAO_COMPLETA = (
+    '**Erro no Suap**: https://suap.ifrn.edu.br/erros/erro/9645/\n\n'
+    '**URL com erro**: https://suap.ifrn.edu.br/progressao_docente/ver_avaliacoes_discente/\n\n'
+    '**Sentry**: None\n\n'
+    '**View**: progressao_docente.views.ver_avaliacoes_discente\n\n'
+    '**Descrição**: não conseguiu visualizar a avaliação em tempo hábil.\n\n'
+    '**Interessado principal**: José Rosinaldo de Luna (20231124120023) (Aluno)\n'
+)
+
+
+def test_extrair_view():
+    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA, profile=SUAP_PROFILE)
+    assert result['view'] == 'progressao_docente.views.ver_avaliacoes_discente'
+
+
+def test_extrair_url_erro():
+    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA, profile=SUAP_PROFILE)
+    assert result['url_erro'] == 'https://suap.ifrn.edu.br/progressao_docente/ver_avaliacoes_discente/'
+
+
+def test_extrair_interessado():
+    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA, profile=SUAP_PROFILE)
+    assert 'José Rosinaldo de Luna' in result['interessado']
+
+
+def test_extrair_descricao_usuario():
+    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA, profile=SUAP_PROFILE)
+    assert 'não conseguiu visualizar' in result['descricao_usuario']
+
+
+def test_extrair_erro_id_do_titulo():
+    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA, profile=SUAP_PROFILE)
+    assert result['erro_id'] == '9645'
+
+
+def test_extrair_erro_id_do_link():
+    desc = '**Erro no Suap**: https://suap.ifrn.edu.br/erros/erro/9999/'
+    result = classify('Título genérico', desc, profile=SUAP_PROFILE)
+    assert result['erro_id'] == '9999'
+
+
+def test_sentry_url_none():
+    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA, profile=SUAP_PROFILE)
+    assert result['sentry_url'] is None
+
+
+def test_sentry_url_presente():
+    desc = '**Sentry**: http://sentry.ifrn.edu.br/issues/5762/'
+    result = classify('Erro 9679 - Enquetes', desc, profile=SUAP_PROFILE)
+    assert result['sentry_url'] == 'http://sentry.ifrn.edu.br/issues/5762/'
+
+
+def test_app_do_titulo():
+    result = classify('Erro 9660 - Eventos', '', profile=SUAP_PROFILE)
+    assert result['app'] == 'eventos'
+
+
+def test_app_do_titulo_alias():
+    result = classify('Erro 9678 - Ensino', '', profile=SUAP_PROFILE)
+    assert result['app'] == 'edu'
+
+
+def test_app_da_url():
+    desc = '**URL com erro**: https://suap.ifrn.edu.br/enquete/responder/1/'
+    result = classify('Título sem app', desc, profile=SUAP_PROFILE)
+    assert result['app'] == 'enquete'
+
+
+def test_labels_erro_suap():
+    result = classify('Erro 9645 - Progressão Docente', DESCRICAO_COMPLETA, profile=SUAP_PROFILE)
+    assert 'origem::erro-suap' in result['labels_sugeridos']
+    assert 'progressao_docente' in result['labels_sugeridos']

--- a/tests/test_config/test_env_settings.py
+++ b/tests/test_config/test_env_settings.py
@@ -1,0 +1,97 @@
+"""Testes para validar que .env gerado no init contém todas as variáveis do app_settings.
+
+Garante que o template env.template (usado no iac init) documenta
+todas as variáveis que app_settings.py aceita.
+"""
+
+from pathlib import Path
+
+
+def _get_env_template_vars() -> set[str]:
+    """Extrai variáveis do env.template (comentadas ou não)."""
+    from iac.config.settings import get_defaults_dir
+
+    template = get_defaults_dir() / 'env.template'
+    content = template.read_text(encoding='utf-8')
+    variables = set()
+    for line in content.splitlines():
+        line = line.strip()
+        if line.startswith('#'):
+            line = line.lstrip('#').strip()
+        if '=' in line and not line.startswith('Copie') and not line.startswith('Hierarquia'):
+            var_name = line.split('=')[0].strip()
+            if var_name and var_name[0].isupper():
+                variables.add(var_name)
+    return variables
+
+
+def _get_app_settings_vars() -> set[str]:
+    """Extrai variáveis aceitas pelo app_settings.py."""
+    return {
+        # LLMSettings (env_prefix: IAC_LLM_)
+        'IAC_LLM_BACKEND',
+        'IAC_LLM_MODEL',
+        'IAC_LLM_URL',
+        'IAC_LLM_KEY',
+        'IAC_LLM_RATE_DELAY',
+        'IAC_LLM_MAX_RETRIES',
+        # API keys diretas
+        'GROQ_API_KEY',
+        'DEEPSEEK_API_KEY',
+        'GEMINI_API_KEY',
+        # GitLabSettings (env_prefix: IAC_GITLAB_)
+        'GITLAB_TOKEN',
+        # AnalyzeSettings (env_prefix: IAC_ANALYZE_)
+        'IAC_ANALYZE_MODE',
+    }
+
+
+def test_env_template_contem_todas_variaveis_do_settings():
+    """O env.template deve documentar TODAS as variáveis que app_settings aceita."""
+    template_vars = _get_env_template_vars()
+    settings_vars = _get_app_settings_vars()
+
+    missing = settings_vars - template_vars
+    assert not missing, f'Variáveis em app_settings mas ausentes no env.template: {missing}'
+
+
+def test_env_template_nao_tem_variaveis_orfas():
+    """O env.template NÃO deve ter variáveis que app_settings não conhece."""
+    template_vars = _get_env_template_vars()
+    settings_vars = _get_app_settings_vars()
+
+    orphans = template_vars - settings_vars
+    assert not orphans, f'Variáveis no env.template mas desconhecidas pelo app_settings: {orphans}'
+
+
+def test_env_gerado_no_init_contem_todas_variaveis(tmp_path):
+    """O .env gerado pelo iac init deve conter todas as variáveis."""
+    from iac.cli import _generate_default_artifacts
+
+    project = tmp_path / 'test-project'
+    project.mkdir()
+    iac_dir = project / '.iac'
+    iac_dir.mkdir()
+    _generate_default_artifacts(iac_dir, {'framework': 'Django'})
+
+    env_content = (iac_dir / '.env').read_text(encoding='utf-8')
+    settings_vars = _get_app_settings_vars()
+
+    for var in settings_vars:
+        assert var in env_content, f'Variável {var} ausente no .env gerado pelo init'
+
+
+def test_env_gerado_tem_instrucoes_de_api_keys(tmp_path):
+    """O .env gerado deve ter instruções de onde obter API keys."""
+    from iac.cli import _generate_default_artifacts
+
+    project = tmp_path / 'test-project'
+    project.mkdir()
+    iac_dir = project / '.iac'
+    iac_dir.mkdir()
+    _generate_default_artifacts(iac_dir, {'framework': 'Django'})
+
+    env_content = (iac_dir / '.env').read_text(encoding='utf-8')
+    assert 'console.groq.com' in env_content
+    assert 'platform.deepseek.com' in env_content
+    assert 'aistudio.google.com' in env_content

--- a/tests/test_config/test_init_artifacts.py
+++ b/tests/test_config/test_init_artifacts.py
@@ -1,0 +1,167 @@
+"""Testes para artefatos gerados pelo iac init.
+
+Garante que ao executar pela primeira vez num repositório novo:
+- .iac/.env é gerado com template comentado
+- .iac/profile.yaml é gerado vazio (só orientações e nome do projeto)
+- .iac/logs/ é criado
+- profile.yaml NÃO contém taxonomy preenchida (usa defaults do IAC)
+- profile.yaml NÃO contém url_skip_segments preenchidos
+- profile.yaml contém nome do projeto
+"""
+
+from pathlib import Path
+
+import yaml
+
+
+def _create_project(tmp_path: Path) -> Path:
+    """Cria estrutura mínima de projeto Django para o init."""
+    project = tmp_path / 'meu-projeto'
+    project.mkdir()
+    (project / 'manage.py').write_text('#!/usr/bin/env python\nimport os\nos.environ["DJANGO_SETTINGS_MODULE"] = "config.settings"\n')
+    settings_dir = project / 'config'
+    settings_dir.mkdir()
+    (settings_dir / '__init__.py').write_text('')
+    (settings_dir / 'settings.py').write_text('INSTALLED_APPS = ["django.contrib.admin"]\n')
+    return project
+
+
+def _run_init(project: Path) -> Path:
+    """Executa _generate_default_artifacts e retorna iac_dir."""
+    from iac.cli import _generate_default_artifacts
+
+    iac_dir = project / '.iac'
+    iac_dir.mkdir(exist_ok=True)
+    result = {'framework': 'Django', 'summary': 'test'}
+    _generate_default_artifacts(iac_dir, result)
+    return iac_dir
+
+
+# ---------------------------------------------------------------------------
+# .env
+# ---------------------------------------------------------------------------
+
+
+def test_env_gerado(tmp_path):
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    env_file = iac_dir / '.env'
+    assert env_file.exists()
+    content = env_file.read_text()
+    assert 'GITLAB_TOKEN' in content
+    assert 'IAC_LLM_BACKEND' in content
+
+
+def test_env_nao_sobrescreve(tmp_path):
+    project = _create_project(tmp_path)
+    iac_dir = project / '.iac'
+    iac_dir.mkdir()
+    env_file = iac_dir / '.env'
+    env_file.write_text('MINHA_VAR=123\n')
+    _run_init(project)
+    assert 'MINHA_VAR=123' in env_file.read_text()
+
+
+# ---------------------------------------------------------------------------
+# profile.yaml
+# ---------------------------------------------------------------------------
+
+
+def test_profile_gerado(tmp_path):
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    profile_file = iac_dir / 'profile.yaml'
+    assert profile_file.exists()
+
+
+def test_profile_tem_nome_do_projeto(tmp_path):
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    content = (iac_dir / 'profile.yaml').read_text()
+    assert 'meu-projeto' in content
+
+
+def test_profile_tem_framework(tmp_path):
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    content = (iac_dir / 'profile.yaml').read_text()
+    assert 'Django' in content
+
+
+def test_profile_taxonomy_vazia(tmp_path):
+    """O profile gerado NÃO deve ter taxonomy preenchida — usa defaults do IAC."""
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    profile = yaml.safe_load((iac_dir / 'profile.yaml').read_text())
+    taxonomy = profile.get('taxonomy', {})
+    assert taxonomy == {} or taxonomy is None
+
+
+def test_profile_url_skip_segments_vazio(tmp_path):
+    """O profile gerado NÃO deve ter url_skip_segments preenchidos."""
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    profile = yaml.safe_load((iac_dir / 'profile.yaml').read_text())
+    segments = profile.get('url_skip_segments', [])
+    assert segments == [] or segments is None
+
+
+def test_profile_rules_vazio(tmp_path):
+    """O profile gerado NÃO deve ter rules preenchidas."""
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    profile = yaml.safe_load((iac_dir / 'profile.yaml').read_text())
+    rules = profile.get('rules', [])
+    assert rules == [] or rules is None
+
+
+def test_profile_issue_patterns_vazio(tmp_path):
+    """O profile gerado NÃO deve ter issue_patterns preenchidos."""
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    profile = yaml.safe_load((iac_dir / 'profile.yaml').read_text())
+    patterns = profile.get('issue_patterns', {})
+    assert patterns == {} or patterns is None
+
+
+def test_profile_app_aliases_vazio(tmp_path):
+    """O profile gerado NÃO deve ter app_aliases preenchidos."""
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    profile = yaml.safe_load((iac_dir / 'profile.yaml').read_text())
+    aliases = profile.get('app_aliases', {})
+    assert aliases == {} or aliases is None
+
+
+def test_profile_nao_sobrescreve(tmp_path):
+    """Se profile já existe, init NÃO sobrescreve."""
+    project = _create_project(tmp_path)
+    iac_dir = project / '.iac'
+    iac_dir.mkdir()
+    profile_file = iac_dir / 'profile.yaml'
+    profile_file.write_text('name: customizado\n')
+    _run_init(project)
+    assert 'customizado' in profile_file.read_text()
+
+
+def test_profile_tem_comentarios_orientativos(tmp_path):
+    """O profile gerado deve ter comentários explicando cada seção."""
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    content = (iac_dir / 'profile.yaml').read_text()
+    assert '# Exemplo:' in content
+    assert 'issue_patterns' in content
+    assert 'app_aliases' in content
+    assert 'taxonomy' in content
+    assert 'rules' in content
+
+
+# ---------------------------------------------------------------------------
+# logs/
+# ---------------------------------------------------------------------------
+
+
+def test_logs_dir_criado(tmp_path):
+    project = _create_project(tmp_path)
+    iac_dir = _run_init(project)
+    assert (iac_dir / 'logs').is_dir()

--- a/tests/test_config/test_init_artifacts.py
+++ b/tests/test_config/test_init_artifacts.py
@@ -165,3 +165,169 @@ def test_logs_dir_criado(tmp_path):
     project = _create_project(tmp_path)
     iac_dir = _run_init(project)
     assert (iac_dir / 'logs').is_dir()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: iac init completo (inspect_project + artifacts)
+# ---------------------------------------------------------------------------
+
+
+def _create_django_project_with_apps(tmp_path: Path) -> Path:
+    """Cria projeto Django com 2 apps para teste end-to-end."""
+    project = tmp_path / 'meu-erp'
+    project.mkdir()
+    (project / 'manage.py').write_text(
+        '#!/usr/bin/env python\nimport os\n'
+        'os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings"\n'
+    )
+    settings_dir = project / 'config'
+    settings_dir.mkdir()
+    (settings_dir / '__init__.py').write_text('')
+    (settings_dir / 'settings.py').write_text(
+        'INSTALLED_APPS = [\n'
+        '    "django.contrib.admin",\n'
+        '    "loja",\n'
+        '    "estoque",\n'
+        ']\n'
+    )
+
+    # App loja
+    loja = project / 'loja'
+    loja.mkdir()
+    (loja / '__init__.py').write_text('')
+    (loja / 'views.py').write_text(
+        'from django.http import HttpResponse\n\n'
+        'def listar_produtos(request):\n'
+        '    return HttpResponse("ok")\n'
+    )
+    (loja / 'models.py').write_text(
+        'from django.db import models\n\n'
+        'class Produto(models.Model):\n'
+        '    nome = models.CharField(max_length=100)\n'
+        '    preco = models.DecimalField(max_digits=10, decimal_places=2)\n'
+    )
+    (loja / 'urls.py').write_text(
+        'from django.urls import path\nfrom . import views\n\n'
+        'urlpatterns = [\n'
+        '    path("produtos/", views.listar_produtos),\n'
+        ']\n'
+    )
+
+    # App estoque
+    estoque = project / 'estoque'
+    estoque.mkdir()
+    (estoque / '__init__.py').write_text('')
+    (estoque / 'views.py').write_text(
+        'from django.http import HttpResponse\n\n'
+        'def verificar_estoque(request):\n'
+        '    return HttpResponse("ok")\n'
+    )
+    (estoque / 'models.py').write_text(
+        'from django.db import models\n\n'
+        'class Item(models.Model):\n'
+        '    quantidade = models.IntegerField()\n'
+    )
+
+    return project
+
+
+def _run_full_init(project: Path) -> Path:
+    """Executa inspect_project + _generate_default_artifacts (init completo)."""
+    from iac.cli import _generate_default_artifacts
+    from iac.inspector import inspect_project
+
+    result = inspect_project(project, force=True)
+    iac_dir = project / '.iac'
+    _generate_default_artifacts(iac_dir, result)
+    return iac_dir
+
+
+def test_e2e_project_json(tmp_path):
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+    assert (iac_dir / 'project.json').exists()
+
+
+def test_e2e_structure_json(tmp_path):
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+    assert (iac_dir / 'structure.json').exists()
+    import json
+    structure = json.loads((iac_dir / 'structure.json').read_text())
+    assert 'apps' in structure
+    assert 'loja' in structure['apps']
+    assert 'estoque' in structure['apps']
+
+
+def test_e2e_graph_json(tmp_path):
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+    assert (iac_dir / 'graph.json').exists()
+    import json
+    graph = json.loads((iac_dir / 'graph.json').read_text())
+    assert 'edges' in graph
+
+
+def test_e2e_env(tmp_path):
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+    env_file = iac_dir / '.env'
+    assert env_file.exists()
+    content = env_file.read_text()
+    assert 'GITLAB_TOKEN' in content
+    assert 'GROQ_API_KEY' in content
+    assert 'DEEPSEEK_API_KEY' in content
+    assert 'GEMINI_API_KEY' in content
+    assert 'IAC_LLM_BACKEND' in content
+    assert 'IAC_LLM_RATE_DELAY' in content
+    assert 'IAC_ANALYZE_MODE' in content
+
+
+def test_e2e_profile_yaml(tmp_path):
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+    profile_file = iac_dir / 'profile.yaml'
+    assert profile_file.exists()
+    content = profile_file.read_text()
+    assert 'meu-erp' in content
+    # Framework detectado pode ser Django ou Python (depende do ambiente)
+    assert 'system_description' in content
+    profile = yaml.safe_load(content)
+    assert profile['name'] == 'meu-erp'
+    assert profile.get('taxonomy', {}) == {} or profile.get('taxonomy') is None
+    assert profile.get('rules', []) == [] or profile.get('rules') is None
+    assert profile.get('app_aliases', {}) == {} or profile.get('app_aliases') is None
+
+
+def test_e2e_logs_dir(tmp_path):
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+    assert (iac_dir / 'logs').is_dir()
+
+
+def test_e2e_diagrams_overview(tmp_path):
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+    assert (iac_dir / 'diagrams' / 'overview.html').exists()
+
+
+def test_e2e_diagrams_per_app(tmp_path):
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+    diagrams_dir = iac_dir / 'diagrams'
+    assert (diagrams_dir / 'loja.html').exists()
+    assert (diagrams_dir / 'estoque.html').exists()
+
+
+def test_e2e_todos_artefatos_presentes(tmp_path):
+    """Validação completa: todos os artefatos do init existem."""
+    project = _create_django_project_with_apps(tmp_path)
+    iac_dir = _run_full_init(project)
+
+    assert (iac_dir / 'project.json').exists(), 'project.json ausente'
+    assert (iac_dir / 'structure.json').exists(), 'structure.json ausente'
+    assert (iac_dir / 'graph.json').exists(), 'graph.json ausente'
+    assert (iac_dir / '.env').exists(), '.env ausente'
+    assert (iac_dir / 'profile.yaml').exists(), 'profile.yaml ausente'
+    assert (iac_dir / 'logs').is_dir(), 'logs/ ausente'
+    assert (iac_dir / 'diagrams' / 'overview.html').exists(), 'diagrams/overview.html ausente'

--- a/tests/test_config/test_profile_merge.py
+++ b/tests/test_config/test_profile_merge.py
@@ -1,0 +1,203 @@
+"""Testes para merge de profiles (defaults + projeto).
+
+Garante que _merge_profiles faz:
+- system_description: projeto sobrescreve
+- rules: projeto sobrescreve
+- issue_patterns: merge (default + projeto)
+- app_aliases: merge (default + projeto)
+- url_skip_segments: UNIÃO (default + projeto)
+- taxonomy.known_tipos: UNIÃO
+- taxonomy.aliases: merge (projeto tem prioridade)
+"""
+
+from iac.config.settings import _merge_profiles
+
+
+# ---------------------------------------------------------------------------
+# Campos simples — projeto sobrescreve default
+# ---------------------------------------------------------------------------
+
+
+def test_system_description_projeto_sobrescreve():
+    defaults = {'system_description': 'Django'}
+    project = {'system_description': 'SUAP (ERP Django)'}
+    result = _merge_profiles(defaults, project)
+    assert result['system_description'] == 'SUAP (ERP Django)'
+
+
+def test_system_description_usa_default_se_projeto_vazio():
+    defaults = {'system_description': 'Django'}
+    project = {}
+    result = _merge_profiles(defaults, project)
+    assert result['system_description'] == 'Django'
+
+
+def test_rules_projeto_sobrescreve():
+    defaults = {'rules': ['regra default']}
+    project = {'rules': ['regra do projeto']}
+    result = _merge_profiles(defaults, project)
+    assert result['rules'] == ['regra do projeto']
+
+
+def test_rules_usa_default_se_projeto_nao_define():
+    defaults = {'rules': ['regra default']}
+    project = {}
+    result = _merge_profiles(defaults, project)
+    assert result['rules'] == ['regra default']
+
+
+# ---------------------------------------------------------------------------
+# issue_patterns — merge (default + projeto)
+# ---------------------------------------------------------------------------
+
+
+def test_issue_patterns_merge():
+    defaults = {'issue_patterns': {'title_regex': r'^Erro\s+(\d+)', 'origin_name': 'erro-sistema'}}
+    project = {'issue_patterns': {'origin_name': 'erro-suap', 'origin_marker': '**Erro no Suap**:'}}
+    result = _merge_profiles(defaults, project)
+    assert result['issue_patterns']['title_regex'] == r'^Erro\s+(\d+)'  # do default
+    assert result['issue_patterns']['origin_name'] == 'erro-suap'  # projeto sobrescreve
+    assert result['issue_patterns']['origin_marker'] == '**Erro no Suap**:'  # do projeto
+
+
+def test_issue_patterns_usa_default_se_projeto_vazio():
+    defaults = {'issue_patterns': {'title_regex': r'^Erro'}}
+    project = {}
+    result = _merge_profiles(defaults, project)
+    assert result['issue_patterns']['title_regex'] == r'^Erro'
+
+
+# ---------------------------------------------------------------------------
+# app_aliases — merge (default + projeto)
+# ---------------------------------------------------------------------------
+
+
+def test_app_aliases_merge():
+    defaults = {'app_aliases': {'Ensino': 'edu'}}
+    project = {'app_aliases': {'Eventos': 'eventos', 'Ensino': 'educacao'}}
+    result = _merge_profiles(defaults, project)
+    assert result['app_aliases']['Eventos'] == 'eventos'  # do projeto
+    assert result['app_aliases']['Ensino'] == 'educacao'  # projeto sobrescreve
+
+
+def test_app_aliases_usa_default_se_projeto_vazio():
+    defaults = {'app_aliases': {'Ensino': 'edu'}}
+    project = {}
+    result = _merge_profiles(defaults, project)
+    assert result['app_aliases'] == {'Ensino': 'edu'}
+
+
+# ---------------------------------------------------------------------------
+# url_skip_segments — UNIÃO (default + projeto)
+# ---------------------------------------------------------------------------
+
+
+def test_url_skip_segments_uniao():
+    defaults = {'url_skip_segments': ['admin', 'api', 'static']}
+    project = {'url_skip_segments': ['djtools']}
+    result = _merge_profiles(defaults, project)
+    segments = set(result['url_skip_segments'])
+    assert 'admin' in segments  # do default
+    assert 'api' in segments  # do default
+    assert 'djtools' in segments  # do projeto
+
+
+def test_url_skip_segments_sem_duplicatas():
+    defaults = {'url_skip_segments': ['admin', 'api']}
+    project = {'url_skip_segments': ['admin', 'djtools']}
+    result = _merge_profiles(defaults, project)
+    assert len(result['url_skip_segments']) == len(set(result['url_skip_segments']))
+
+
+def test_url_skip_segments_usa_default_se_projeto_vazio():
+    defaults = {'url_skip_segments': ['admin', 'api']}
+    project = {}
+    result = _merge_profiles(defaults, project)
+    assert set(result['url_skip_segments']) == {'admin', 'api'}
+
+
+# ---------------------------------------------------------------------------
+# taxonomy.known_tipos — UNIÃO
+# ---------------------------------------------------------------------------
+
+
+def test_taxonomy_known_tipos_uniao():
+    defaults = {'taxonomy': {'known_tipos': ['tipo::bug', 'tipo::configuracao']}}
+    project = {'taxonomy': {'known_tipos': ['tipo::custom']}}
+    result = _merge_profiles(defaults, project)
+    known = result['taxonomy']['known_tipos']
+    assert 'tipo::bug' in known
+    assert 'tipo::configuracao' in known
+    assert 'tipo::custom' in known
+
+
+def test_taxonomy_known_tipos_usa_default_se_projeto_vazio():
+    defaults = {'taxonomy': {'known_tipos': ['tipo::bug']}}
+    project = {}
+    result = _merge_profiles(defaults, project)
+    assert 'tipo::bug' in result['taxonomy']['known_tipos']
+
+
+# ---------------------------------------------------------------------------
+# taxonomy.aliases — merge (projeto tem prioridade)
+# ---------------------------------------------------------------------------
+
+
+def test_taxonomy_aliases_merge():
+    defaults = {'taxonomy': {'aliases': {'tipo::logica-incorreta': 'tipo::bug'}}}
+    project = {'taxonomy': {'aliases': {'tipo::avaliacao-nao-disponivel': 'tipo::prazo-expirado'}}}
+    result = _merge_profiles(defaults, project)
+    aliases = result['taxonomy']['aliases']
+    assert aliases['tipo::logica-incorreta'] == 'tipo::bug'  # do default
+    assert aliases['tipo::avaliacao-nao-disponivel'] == 'tipo::prazo-expirado'  # do projeto
+
+
+def test_taxonomy_aliases_projeto_sobrescreve():
+    defaults = {'taxonomy': {'aliases': {'tipo::custom': 'tipo::bug'}}}
+    project = {'taxonomy': {'aliases': {'tipo::custom': 'tipo::configuracao'}}}
+    result = _merge_profiles(defaults, project)
+    assert result['taxonomy']['aliases']['tipo::custom'] == 'tipo::configuracao'
+
+
+# ---------------------------------------------------------------------------
+# Merge completo — cenário realista
+# ---------------------------------------------------------------------------
+
+
+def test_merge_completo():
+    """Simula merge de defaults + profile SUAP."""
+    defaults = {
+        'name': '',
+        'system_description': 'Django',
+        'rules': [],
+        'issue_patterns': {},
+        'app_aliases': {},
+        'url_skip_segments': ['admin', 'api', 'static', 'media', 'accounts'],
+        'taxonomy': {
+            'known_tipos': ['tipo::bug', 'tipo::nao-e-erro', 'tipo::prazo-expirado'],
+            'aliases': {'tipo::logica-incorreta': 'tipo::bug'},
+        },
+    }
+    project = {
+        'name': 'SUAP',
+        'system_description': 'SUAP (ERP Django)',
+        'rules': ['Regra SUAP 1'],
+        'issue_patterns': {'origin_name': 'erro-suap'},
+        'app_aliases': {'Ensino': 'edu'},
+        'url_skip_segments': ['djtools'],
+        'taxonomy': {
+            'aliases': {'tipo::avaliacao-nao-disponivel': 'tipo::prazo-expirado'},
+        },
+    }
+    result = _merge_profiles(defaults, project)
+
+    assert result['name'] == 'SUAP'
+    assert result['system_description'] == 'SUAP (ERP Django)'
+    assert result['rules'] == ['Regra SUAP 1']
+    assert result['issue_patterns'] == {'origin_name': 'erro-suap'}
+    assert result['app_aliases'] == {'Ensino': 'edu'}
+    assert 'admin' in result['url_skip_segments']
+    assert 'djtools' in result['url_skip_segments']
+    assert 'tipo::bug' in result['taxonomy']['known_tipos']
+    assert result['taxonomy']['aliases']['tipo::logica-incorreta'] == 'tipo::bug'
+    assert result['taxonomy']['aliases']['tipo::avaliacao-nao-disponivel'] == 'tipo::prazo-expirado'


### PR DESCRIPTION
## Resumo

Core 100% genérico — zero referências a SUAP no código de produção. Toda configuração específica de cliente via `.iac/profile.yaml`.

## Mudanças

### Core genérico (#62)
- **Classifier** genérico — `_APP_ALIASES`, regex, field markers removidos do código, configuráveis via `profile.yaml → issue_patterns, app_aliases`
- **Prompts** parametrizados — `{system_description}` e `{rules}` injetados do profile
- **Taxonomia** configurável — `KNOWN_TIPOS` e `_LABEL_ALIASES` removidos de `utils.py`, carregados de `profile.yaml → taxonomy`
- **Zero "SUAP"** em `src/iac/**/*.py`

### Profile configurável
- `defaults/profile.yaml` — defaults de merge (6 known_tipos, 18 aliases)
- `defaults/profile.init.yaml` — template vazio com orientações (gerado pelo init)
- `_merge_profiles()` — defaults + projeto: união de tipos/segments, merge de aliases
- Pipeline: `load_profile()` → merge → profile propagado a classifier, prompts, runner, loop

### Remoção do config.yaml
- Toda configuração via `.env` + `profile.yaml`
- `iac config` edita `.iac/.env` diretamente

### Parser e taxonomia expandidos
- Labels sem `tipo::` prefix aceitos (`bug` → `tipo::bug`)
- 10+ novos aliases temporais
- Subclassificação normalizada
- Prompt 3 condicional (só se tipo != None)

### Init completo
- `iac init` gera: project.json, structure.json, graph.json, .env, profile.yaml, logs/, diagrams/
- `.env` copiado de `defaults/env.template` (todas as variáveis documentadas)
- `profile.yaml` copiado de `defaults/profile.init.yaml` (vazio com orientações)
- Diagramas: overview.html + {app}.html por app detectado
- Nome e framework do projeto personalizados automaticamente

### Testes
- 198 testes (era 160)
- 16 testes de merge de profiles (todas as regras de merge)
- 22 testes de init (13 unitários + 9 E2E: todos os artefatos validados)
- Testes do classifier separados: core genérico + SUAP com profile fixture

## Test plan

- [x] `ruff check src/` → zero erros
- [x] `pylint --max-module-lines=400` → ok
- [x] `pytest tests/` → 198 passed
- [x] Zero "SUAP" em `src/iac/**/*.py`
- [x] Init E2E: todos os artefatos gerados e validados
- [x] Merge de profiles: todas as regras testadas
- [ ] Bateria Groq: 9 cenários rodando

Closes #62 (fases 1-4)
Ref #57, #64